### PR TITLE
Added Outlet, overrides for Fans and Outlets

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function VeraLinkPlatform(log, config)
     this.rooms      = {};
     this.HAPNode     = {'request':request, 'uuid':uuid, 'Accessory':Accessory, 'Service':Service, 'Characteristic':Characteristic, 'debug':debug, 'hashing':hashing, 'return': true};
     
-    defaults = {'bridged': true,'includesensor': false, 'dimmertest': false, 'ignorerooms': [], 'ignoredevices': [], 'securitypoll': 2000};
+    defaults = {'bridged': true,'includesensor': false, 'dimmertest': false, 'ignorerooms': [], 'ignoredevices': [], 'securitypoll': 2000, 'Fans': [], 'Outlets': []};
     
     Veraconfig = merge_options(defaults, Veraconfig);
     Veraconfig = merge_options(Veraconfig,config);

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -144,31 +144,43 @@ module.exports = function(HAPnode, config)
     module.processdevices = function(list, verainfo)
     {
         var accessories = [];
+        var category;
         
         list.forEach(function(device)
         {
-            switch (device.category)
+            category = device.category;
+
+            // Override category?
+            if(typeof config.Fans !== 'undefined' && config.Fans && config.Fans.constructor === Array)
             {
-                case 2: // Dimmable Light: 
-                        if(config.dimmertest)
-                        {
-                            // Specifically looking the word "fan" in the device name, very shaky assumption
-                            if (device.name.toLowerCase().includes("fan")){
-                                var Fan    = require("./types/fan.js")(HAPnode,config,module);
-                                HAPnode.debug('------ Fan Added: %s', device.name + ' ID:' +device.id);
-                                accessories.push(Fan.newDevice(device));
-                            } else {
-                                var DimmableLight    = require("./types/dimmer.js")(HAPnode,config,module);
-                                HAPnode.debug('------ Dimmer light Added: %s', device.name + ' ID:' +device.id);
-                                accessories.push(DimmableLight.newDevice(device));
-                            }
-                        }
+                if(config.Fans.indexOf(device.id) >= 0)
+                {
+                    HAPnode.debug('------ Overriding device category to Fan: %s', device.name + ' ID:' +device.id);
+                    category = 10000; // Fan
+                }
+            }
+            if(typeof config.Outlets !== 'undefined' && config.Outlets && config.Outlets.constructor === Array)
+            {
+                if(config.Outlets.indexOf(device.id) >= 0)
+                {
+                    HAPnode.debug('------ Overriding device category to Outlet: %s', device.name + ' ID:' +device.id);
+                    category = 10001; // Outlet
+                }
+            }
+            
+            
+            switch (category)
+            {
+                case 2: // Dimmable Light
+                        var DimmableLight    = require("./types/dimmer.js")(HAPnode,config,module);
+                        accessories.push(DimmableLight.newDevice(device));
+                        HAPnode.debug('------ Dimmer Light Added: %s', device.name + ' ID:' +device.id);
                     break;
 
-                case 3: // Switch
+                case 3: // Light Switch
                         var Switch          = require("./types/switch.js")(HAPnode,config,module);
                         accessories.push(Switch.newDevice(device));
-                        HAPnode.debug('------ Switch Added: %s', device.name + ' ID:' +device.id);
+                        HAPnode.debug('------ Light Switch Added: %s', device.name + ' ID:' +device.id);
                     break;
 
                 case 4: // Security Sensor
@@ -180,20 +192,33 @@ module.exports = function(HAPnode, config)
                         }
                     break;
 
-                case 7: // Door lock
+                case 7: // Door Lock
                         var Lock            = require("./types/lock.js")(HAPnode,config,module);
-                        HAPnode.debug('------ Lock Added: %s', device.name + ' ID:' +device.id);
                         accessories.push(Lock.newDevice(device));
+                        HAPnode.debug('------ Lock Added: %s', device.name + ' ID:' +device.id);
                     break;
 
-                case 17: // Temp sensor
+                case 17: // Temp Sensor
                         if(config.includesensor)
                         {
                             var Tempsense       = require("./types/tempsense.js")(HAPnode,config,module);
-                            HAPnode.debug('------ Temp sensor Added: %s', device.name + ' ID:' +device.id);
                             accessories.push(Tempsense.newDevice(device));
+                            HAPnode.debug('------ Temp Sensor Added: %s', device.name + ' ID:' +device.id);
                         }
                     break;
+
+                case 10000: // Fan
+                        var Fan = require("./types/fan.js")(HAPnode,config,module);
+                        HAPnode.debug('------ Fan Added: %s', device.name + ' ID:' +device.id);
+                        accessories.push(Fan.newDevice(device));
+                    break;
+
+                case 10001: // Outlet
+                        var Outlet = require("./types/outlet.js")(HAPnode,config,module);
+                        HAPnode.debug('------ Outlet Added: %s', device.name + ' ID:' +device.id);
+                        accessories.push(Outlet.newDevice(device));
+                    break;
+
             }
         });    
             

--- a/lib/types/outlet.js
+++ b/lib/types/outlet.js
@@ -1,0 +1,106 @@
+module.exports = function(HAPnode, config, functions)
+{
+    var Accessory       = HAPnode.Accessory;
+    var Service         = HAPnode.Service;
+    var Characteristic  = HAPnode.Characteristic;
+    var uuid            = HAPnode.uuid;
+    var debug           = HAPnode.debug;
+
+    var module  = {};
+    
+    module.newDevice = function(device)
+    {
+        var Switch = {
+            powerOn: (parseInt(device.status) === 1)?true:false,
+
+            setPowerOn: function(on)
+            { 
+                if (on)
+                {
+                    binaryState     = 1;
+                    Switch.powerOn  = true;
+                }
+                else
+                {
+                    binaryState     = 0;
+                    Switch.powerOn  = false;
+                }
+
+                res = HAPnode.request('GET',"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState);
+
+                if (res.statusCode === 200)
+                {
+                    status = (Switch.powerOn)?'On':'Off';
+                    debug("The %s has been turned %s", device.name, status);
+                }
+                else
+                {
+                    debug("Error while turning the %s on/off %s", device.name);
+                }
+            },
+            getStatus: function()
+            {
+                res = HAPnode.request('GET','http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status');
+
+                if (res.statusCode === 200)
+                {
+                    data = parseInt(res.body.toString('utf8'));
+                    this.powerOn = (data === 1)?true:false;
+                    status = (this.powerOn)?'On':'Off';
+                    
+                    debug("Status for the outlet %s is %s", device.name, status);
+                    return this.powerOn;
+                }
+                else
+                {
+                    debug("Error while getting the status for %s", device.name);
+                    return this.powerOn;
+                }
+            },
+            identify: function()
+            {
+                debug("Identify the outlet %s", device.name);
+            }
+        };
+
+        var outletUUID = uuid.generate('device:outlet:'+config.cardinality+':'+device.id);
+
+        var outlet = new Accessory(device.name, outletUUID);
+
+        outlet.username  = functions.genMac('device:'+config.cardinality+':'+device.id);
+        outlet.pincode   = config.pincode;
+        outlet.deviceid  = device.id;
+
+        outlet
+            .getService(Service.AccessoryInformation)
+            .setCharacteristic(Characteristic.Manufacturer, "Z-Wave")
+            .setCharacteristic(Characteristic.Model, "1.0")
+            .setCharacteristic(Characteristic.SerialNumber, "N/A");
+
+        outlet.on('identify', function(paired, callback) {
+            Switch.identify();
+            callback(); // success
+        });
+
+        outlet
+            .addService(Service.Outlet, device.name)
+            .getCharacteristic(Characteristic.On)
+            .on('set', function(value, callback) {
+                Switch.setPowerOn(value);
+                callback();
+            });
+
+        outlet
+            .getService(Service.Outlet)
+            .getCharacteristic(Characteristic.On)
+            .on('get', function(callback) {
+                var err = null;
+
+                callback(err, Switch.getStatus());
+            });
+          
+        return outlet;
+    };
+    
+    return module;
+};


### PR DESCRIPTION
This patch removes the “dimmertest” as the dimmers seem to work fine.
It provides an “Outlet” type. This can be configured in the Home app to be a Light, a Fan, or an Outlet. In other words, an Outlet is a Switch that can be configured to be something other than a Light.

In order to declare a device an Outlet, use config.js
“Outlets”: [123,124,125],
this will override the device type to outlet for these IDs (remember: these are Vera IDs as displayed by the plugin, not ZWave IDs).

For completeness, the patch also includes a “Fans” override (this is for fans that can get/set rotation speed. I don’t have one so it’s untested.
