### PR TITLE
Cached Status, Less Noise

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,254 +1,282 @@
 module.exports = function(HAPnode, config)
 {
     var module  = {};
+    var debug = HAPnode.debug;
 
-    module.getVeraInfo = function()
-    {
-        var url = "http://" + config.veraIP + ":3480/data_request?id=lu_sdata";
-        return HAPnode.request(
-            {
-                method: 'GET',
-                uri: url,
-                json: true
-            }).then(function (data) {
-                HAPnode.debug('Using url: '+url);
-                devices = {};
-                if(typeof data === 'object')
-                {
-                    data.devices.forEach(function(device)
-                    {
-                        if(typeof devices[device.room] ==='undefined')
-                        {
-                            devices[device.room] = [];
-                        }
+      module.cacheStatus = function(){
+        debug('Caching status...');
+        HAPnode.request({
+            method:'GET',
+            uri: 'http://'+config.veraIP+':3480/data_request?id=sdata'
+        }).then(function(status){
+          module.cache = JSON.parse(status);
+        })
+      },
 
-                        devices[device.room].push(device);
-                    });
-
-                    return({'rooms': data.rooms,'devices_by_room': devices, 'devices_full_list': data.devices, 'scenes': data.scenes, 'temperature': data.temperature});
-                }
-                else
-                {
-                    return(null);
-                }
-        }.bind(this)).catch(function (err) {
-            HAPnode.debug("Request error:"+err);
-        });
-    };
-
-    module.processall = function(verainfo)
-    {
-        accessories = module.processdevices(verainfo.devices_full_list, verainfo);
-
-        if(typeof HAPnode.return === 'undefined')
-        {
-            accessories.forEach(function(accessory)
-            {
-                if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
-                {
-                    if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
-                    {
-                        HAPnode.debug("Ignore Device "+accessory.deviceid+"-"+ accessory.displayName);
-                        return;
-                    }
-                }
-
-                var Port = config.happort + 100 +(accessory.deviceid*2);
-
-                accessory.publish({
-                    port: Port,
-                    username: accessory.username,
-                    pincode: accessory.pincode
-                });
-            });
+      module.getVariable = function(id, property){
+        // console.log('cache is', module.cache);
+        if (!module.cache){
+          return false;
         }
-        else
-        {
-            returnlist = [];
-            accessories.forEach(function(accessory)
-            {
-                if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
-                {
-                    if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
-                    {
-                        console.log("Ignore Device "+accessory.deviceid+": "+ accessory.displayName);
-                        return;
-                    }
-                }
-
-                console.log("Process Device "+accessory.deviceid+": "+ accessory.displayName);
-                returnlist.push(accessory);
-            });
-
-            return returnlist;
-        }
-    };
-
-    module.processrooms = function(verainfo)
-    {
-        verainfo.rooms.forEach(function(room)
-        {
-            if(typeof config.ignorerooms !== 'undefined' && config.ignorerooms && config.ignorerooms.constructor === Array)
-            {
-                if(typeof config.ignorerooms[room.id] !== 'undefined')
-                {
-                    HAPnode.debug("Ignore Room "+room.id+"-"+room.name);
-                    return;
-                }
-            }
-
-            // Start by creating our Bridge which will host all loaded Accessories
-            var bridge = new HAPnode.Bridge(room.name, HAPnode.uuid.generate(room.name));
-
-            // Listen for bridge identification event
-            bridge.on('identify', function(paired, callback)
-            {
-                HAPnode.debug("Node Bridge identify");
-                callback(); // success
-            });
-
-            HAPnode.debug('Start room: %s', room.name);
-            if(typeof verainfo.devices_by_room[room.id] !== "undefined")
-            {
-                accessories = module.processdevices(verainfo.devices_by_room[room.id], verainfo);
-            }
-
-            if(typeof accessories === "object")
-            {
-                // Add them all to the bridge
-                accessories.forEach(function(accessory)
-                {
-                    if(typeof accessory === 'object')
-                    {
-                        if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
-                        {
-                            if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
-                            {
-                                HAPnode.debug("Ignore Device "+accessory.deviceid+"-"+ accessory.displayName);
-                                return;
-                            }
-                        }
-                        bridge.addBridgedAccessory(accessory);
-                    }
-                });
-
-                var Port = config.happort + (room.id*2);
-                HAPnode.debug('------ Pinconde: %s',config.pincode);
-                // Publish the Bridge on the local network.
-
-                bridge.publish({
-                  username:     module.genMac('roomID:'+config.cardinality+':'+room.id),
-                  port:         Port,
-                  pincode:      config.pincode,
-                  category:     HAPnode.Accessory.Categories.OTHER
-                });
-            }
+        device = module.cache.devices.find(function(device, index){
+          return device.id === id;
         });
-    };
+        return device[property];
+      },
 
-    module.processdevices = function(list, verainfo)
-    {
-        var accessories = [];
+      module.getVeraInfo = function()
+      {
+          var url = "http://" + config.veraIP + ":3480/data_request?id=lu_sdata";
+          return HAPnode.request(
+              {
+                  method: 'GET',
+                  uri: url,
+                  json: true
+              }).then(function (data) {
+                  HAPnode.debug('Using url: '+url);
+                  devices = {};
+                  if(typeof data === 'object')
+                  {
+                      data.devices.forEach(function(device)
+                      {
+                          if(typeof devices[device.room] ==='undefined')
+                          {
+                              devices[device.room] = [];
+                          }
 
-        list.forEach(function(device)
-        {
-            switch (device.category)
-            {
-                case 2: // Dimmable Light:
-                        if (config.includeRGB && device.subcategory == 4){
-                            var ColoredLight = require("./types/rgb_light.js")(HAPnode,config,module);
-                            HAPnode.debug('------ Coloured light Added: %s', device.name + ' ID:' +device.id);
-                            accessories.push(ColoredLight.newDevice(device));
-                        // Specifically looking the word "fan" in the device name, very shaky assumption
-                        } else if ((device !== null) && (device !== undefined) && (typeof(device.name) === 'string') && (device.name.toLowerCase().includes("fan"))){
-                            var Fan    = require("./types/fan.js")(HAPnode,config,module);
-                            HAPnode.debug('------ Fan Added: %s', device.name + ' ID:' +device.id);
-                            accessories.push(Fan.newDevice(device));
-                        } else {
-                            var DimmableLight    = require("./types/dimmer.js")(HAPnode,config,module);
-                            HAPnode.debug('------ Dimmer light Added: %s', device.name + ' ID:' +device.id);
-                            accessories.push(DimmableLight.newDevice(device));
-                        }
-                    break;
+                          devices[device.room].push(device);
+                      });
 
-                case 3: // Switch
-                        if(device.subcategory > 0)
-                        {
-                            console.log('we have a switch')
-                            var Switch = require("./types/switch.js")(HAPnode,config,module);
-                            accessories.push(Switch.newDevice(device));
-                            HAPnode.debug('------ Switch Added: %s', device.name + ' ID:' +device.id);
-                        }
-                        else
-                        {
-                            var Lightbulb = require("./types/light.js")(HAPnode,config,module);
-                            accessories.push(Lightbulb.newDevice(device));
-                            HAPnode.debug('------ Lightbulb Added: %s', device.name + ' ID:' +device.id);
-                        }
-                    break;
+                      return({'rooms': data.rooms,'devices_by_room': devices, 'devices_full_list': data.devices, 'scenes': data.scenes, 'temperature': data.temperature});
+                  }
+                  else
+                  {
+                      return(null);
+                  }
+          }.bind(this)).catch(function (err) {
+              HAPnode.debug("Request error:"+err);
+          });
+      },
 
-                case 4: // Security Sensor
-                    //Deactivated for the moment
-//                        if(config.includesensor)
-//                        {
-//                            var SecuritySensor = require("./types/securitysense.js")(HAPnode,config,module);
-//                            accessories.push(SecuritySensor.newDevice(device));
-//                            HAPnode.debug('------ Security Sensor Added: %s', device.name + ' ID:' +device.id);
-//                        }
-                    break;
+      module.processall = function(verainfo)
+      {
+          accessories = module.processdevices(verainfo.devices_full_list, verainfo);
 
-                case 5:
-                    if(config.includethermostat){
-                        var Thermostat            = require("./types/thermostat.js")(HAPnode,config,module);
-                        HAPnode.debug('------ Thermostat Added: %s', device.name + ' ID:' +device.id);
-                        accessories.push(Thermostat.newDevice(device, verainfo.temperature));
-                    };
-                    break;
+          if(typeof HAPnode.return === 'undefined')
+          {
+              accessories.forEach(function(accessory)
+              {
+                  if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
+                  {
+                      if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
+                      {
+                          HAPnode.debug("Ignore Device "+accessory.deviceid+"-"+ accessory.displayName);
+                          return;
+                      }
+                  }
 
-                case 7: // Door lock
-                        var Lock            = require("./types/lock.js")(HAPnode,config,module);
-                        HAPnode.debug('------ Lock Added: %s', device.name + ' ID:' +device.id);
-                        accessories.push(Lock.newDevice(device));
-                    break;
+                  var Port = config.happort + 100 +(accessory.deviceid*2);
 
-                case 17: // Temp sensor
-                        if(config.includesensor)
-                        {
-                            var Tempsense       = require("./types/tempsense.js")(HAPnode,config,module);
-                            HAPnode.debug('------ Temp sensor Added: %s', device.name + ' ID:' +device.id);
-                            accessories.push(Tempsense.newDevice(device));
-                        }
-                    break;
-            }
-        });
+                  accessory.publish({
+                      port: Port,
+                      username: accessory.username,
+                      pincode: accessory.pincode
+                  });
+              });
+          }
+          else
+          {
+              returnlist = [];
+              accessories.forEach(function(accessory)
+              {
+                  if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
+                  {
+                      if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
+                      {
+                          console.log("Ignore Device "+accessory.deviceid+": "+ accessory.displayName);
+                          return;
+                      }
+                  }
 
-        accessories = module.processscenes(accessories, verainfo.scenes);
+                  console.log("Process Device "+accessory.deviceid+": "+ accessory.displayName);
+                  returnlist.push(accessory);
+              });
 
-        return accessories;
-    };
+              return returnlist;
+          }
+      },
 
-    module.processscenes = function(accessories, list)
-    {
-        list.forEach(function(scene)
-        {
-            var Scene = require("./types/scene.js")(HAPnode,config,module);
-            accessories.push(Scene.newScene(scene));
-            HAPnode.debug('------ Scene Added: %s', scene.name + ' ID:' +scene.id);
-        });
+      module.processrooms = function(verainfo)
+      {
+          verainfo.rooms.forEach(function(room)
+          {
+              if(typeof config.ignorerooms !== 'undefined' && config.ignorerooms && config.ignorerooms.constructor === Array)
+              {
+                  if(typeof config.ignorerooms[room.id] !== 'undefined')
+                  {
+                      HAPnode.debug("Ignore Room "+room.id+"-"+room.name);
+                      return;
+                  }
+              }
 
-        return accessories;
-    };
+              // Start by creating our Bridge which will host all loaded Accessories
+              var bridge = new HAPnode.Bridge(room.name, HAPnode.uuid.generate(room.name));
 
-    module.genMac = function genMac(str)
-    {
-        var hash = HAPnode.hashing('md5').update(str).digest("hex").toUpperCase();
-        return hash[0] + hash[1] + ":" +
-               hash[2] + hash[3] + ":" +
-               hash[4] + hash[5] + ":" +
-               hash[6] + hash[7] + ":" +
-               hash[8] + hash[9] + ":" +
-               hash[10] + hash[11];
-    };
+              // Listen for bridge identification event
+              bridge.on('identify', function(paired, callback)
+              {
+                  HAPnode.debug("Node Bridge identify");
+                  callback(); // success
+              });
+
+              HAPnode.debug('Start room: %s', room.name);
+              if(typeof verainfo.devices_by_room[room.id] !== "undefined")
+              {
+                  accessories = module.processdevices(verainfo.devices_by_room[room.id], verainfo);
+              }
+
+              if(typeof accessories === "object")
+              {
+                  // Add them all to the bridge
+                  accessories.forEach(function(accessory)
+                  {
+                      if(typeof accessory === 'object')
+                      {
+                          if(typeof config.ignoredevices !== 'undefined' && config.ignoredevices && config.ignoredevices.constructor === Array)
+                          {
+                              if(config.ignoredevices.indexOf(accessory.deviceid) >= 0)
+                              {
+                                  HAPnode.debug("Ignore Device "+accessory.deviceid+"-"+ accessory.displayName);
+                                  return;
+                              }
+                          }
+                          bridge.addBridgedAccessory(accessory);
+                      }
+                  });
+
+                  var Port = config.happort + (room.id*2);
+                  HAPnode.debug('------ Pinconde: %s',config.pincode);
+                  // Publish the Bridge on the local network.
+
+                  bridge.publish({
+                    username:     module.genMac('roomID:'+config.cardinality+':'+room.id),
+                    port:         Port,
+                    pincode:      config.pincode,
+                    category:     HAPnode.Accessory.Categories.OTHER
+                  });
+              }
+          });
+      },
+
+      module.processdevices = function(list, verainfo)
+      {
+          var accessories = [];
+
+          list.forEach(function(device)
+          {
+              switch (device.category)
+              {
+                  case 2: // Dimmable Light:
+                          if (config.includeRGB && device.subcategory == 4){
+                              var ColoredLight = require("./types/rgb_light.js")(HAPnode,config,module);
+                              HAPnode.debug('------ Coloured light Added: %s', device.name + ' ID:' +device.id);
+                              accessories.push(ColoredLight.newDevice(device));
+                          // Specifically looking the word "fan" in the device name, very shaky assumption
+                          } else if ((device !== null) && (device !== undefined) && (typeof(device.name) === 'string') && (device.name.toLowerCase().includes("fan"))){
+                              var Fan    = require("./types/fan.js")(HAPnode,config,module);
+                              HAPnode.debug('------ Fan Added: %s', device.name + ' ID:' +device.id);
+                              accessories.push(Fan.newDevice(device));
+                          } else {
+                              var DimmableLight    = require("./types/dimmer.js")(HAPnode,config,module);
+                              HAPnode.debug('------ Dimmer light Added: %s', device.name + ' ID:' +device.id);
+                              accessories.push(DimmableLight.newDevice(device));
+                          }
+                      break;
+
+                  case 3: // Switch
+                          if(device.subcategory > 0)
+                          {
+                              console.log('we have a switch')
+                              var Switch = require("./types/switch.js")(HAPnode,config,module);
+                              accessories.push(Switch.newDevice(device));
+                              HAPnode.debug('------ Switch Added: %s', device.name + ' ID:' +device.id);
+                          }
+                          else
+                          {
+                              var Lightbulb = require("./types/light.js")(HAPnode,config,module);
+                              accessories.push(Lightbulb.newDevice(device));
+                              HAPnode.debug('------ Lightbulb Added: %s', device.name + ' ID:' +device.id);
+                          }
+                      break;
+
+                  case 4: // Security Sensor
+                      //Deactivated for the moment
+  //                        if(config.includesensor)
+  //                        {
+  //                            var SecuritySensor = require("./types/securitysense.js")(HAPnode,config,module);
+  //                            accessories.push(SecuritySensor.newDevice(device));
+  //                            HAPnode.debug('------ Security Sensor Added: %s', device.name + ' ID:' +device.id);
+  //                        }
+                      break;
+
+                  case 5:
+                      if(config.includethermostat){
+                          var Thermostat            = require("./types/thermostat.js")(HAPnode,config,module);
+                          HAPnode.debug('------ Thermostat Added: %s', device.name + ' ID:' +device.id);
+                          accessories.push(Thermostat.newDevice(device, verainfo.temperature));
+                      };
+                      break;
+
+                  case 7: // Door lock
+                          var Lock            = require("./types/lock.js")(HAPnode,config,module);
+                          HAPnode.debug('------ Lock Added: %s', device.name + ' ID:' +device.id);
+                          accessories.push(Lock.newDevice(device));
+                      break;
+
+                  case 17: // Temp sensor
+                          if(config.includesensor)
+                          {
+                              var Tempsense       = require("./types/tempsense.js")(HAPnode,config,module);
+                              HAPnode.debug('------ Temp sensor Added: %s', device.name + ' ID:' +device.id);
+                              accessories.push(Tempsense.newDevice(device));
+                          }
+                      break;
+              }
+          });
+
+          accessories = module.processscenes(accessories, verainfo.scenes);
+
+          return accessories;
+      },
+
+      module.processscenes = function(accessories, list)
+      {
+          list.forEach(function(scene)
+          {
+              var Scene = require("./types/scene.js")(HAPnode,config,module);
+              accessories.push(Scene.newScene(scene));
+              HAPnode.debug('------ Scene Added: %s', scene.name + ' ID:' +scene.id);
+          });
+
+          return accessories;
+      },
+
+      module.genMac = function genMac(str)
+      {
+          var hash = HAPnode.hashing('md5').update(str).digest("hex").toUpperCase();
+          return hash[0] + hash[1] + ":" +
+                 hash[2] + hash[3] + ":" +
+                 hash[4] + hash[5] + ":" +
+                 hash[6] + hash[7] + ":" +
+                 hash[8] + hash[9] + ":" +
+                 hash[10] + hash[11];
+      };
+
+    setInterval(function() {
+
+        module.cacheStatus();
+
+    }, 3000);
 
     return module;
 };

--- a/lib/types/dimmer.js
+++ b/lib/types/dimmer.js
@@ -64,7 +64,7 @@ module.exports = function(HAPnode, config, functions)
                     }).catch(function (err) {
                         HAPnode.debug("Request error:"+err);
                     });
-                    
+
                     this.onproc = false;
 
                     if(this.changebright)
@@ -82,47 +82,17 @@ module.exports = function(HAPnode, config, functions)
             },
             getStatus: function()
             {
-                return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status', resolveWithFullResponse: true}).then(function (res)
-                {
-                    if (res.statusCode === 200)
-                    {
-                        data = parseInt(res.body.toString('utf8'));
-                        this.powerOn = (data === 1)?true:false;
-                        status = (this.powerOn)?'On':'Off';
-
-                        debug("Status for the light %s is %s", device.name, status);
-                        return this.powerOn;
-                    }
-                    else
-                    {
-                        debug("Error while getting the status for %s", device.name);
-                        return this.powerOn;
-                    }
-                }).catch(function (err) {
-                    HAPnode.debug("Request error:"+err);
-                });
+                debug("Making status request for device %s", device.name);
+                var status = parseInt(functions.getVariable(device.id, 'status'));
+                debug("Status is ", status);
+                return status;
             },
             getBrightness: function()
             {
-                return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&output_format=xml&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:Dimming1&Variable=LoadLevelStatus', resolveWithFullResponse: true}).then(function (res)
-                {
-                    if (res.statusCode === 200)
-                    {
-                        data = parseInt(res.body.toString('utf8'));
-                        this.brightness = data;
-
-                        debug("Status for the light %s is %s%", device.name, this.brightness);
-
-                        return this.brightness;
-                    }
-                    else
-                    {
-                        debug("Error while getting the status for %s", device.name);
-                        return this.brightness;
-                    }
-                }).catch(function (err) {
-                    HAPnode.debug("Request error:"+err);
-                });
+              debug("Making level request for device %s", device.name);
+              level = parseInt(functions.getVariable(device.id, 'level'));
+              debug("Level is ", level);
+              return level;
             },
             identify: function()
             {
@@ -162,9 +132,7 @@ module.exports = function(HAPnode, config, functions)
             .getCharacteristic(Characteristic.On)
             .on('get', function(callback) {
                 var err = null;
-                Dimmer.getStatus().then(function(val){
-                    callback(err, val);
-                });
+                callback(err, Dimmer.getStatus());
             });
 
         light
@@ -172,9 +140,7 @@ module.exports = function(HAPnode, config, functions)
             .addCharacteristic(Characteristic.Brightness)
             .on('get', function(callback) {
                 var err = null;
-                Dimmer.getBrightness().then(function(val){
-                    callback(err, val);
-                });
+                callback(err, Dimmer.getBrightness());
             })
             .on('set', function(value, callback) {
                 Dimmer.setBrightness(value);

--- a/lib/types/fan.js
+++ b/lib/types/fan.js
@@ -75,46 +75,17 @@ module.exports = function(HAPnode, config, functions)
             },
             getStatus: function()
             {
-                res = HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status'});
-
-                if (res.statusCode === 200)
-                {
-                    data = parseInt(res.body.toString('utf8'));
-                    this.powerOn = (data === 1)?true:false;
-                    status = (this.powerOn)?'On':'Off';
-
-                    debug("Status for the fan %s is %s", device.name, status);
-                    return this.powerOn;
-                }
-                else
-                {
-                    debug("Error while getting the status for %s", device.name);
-                    return this.powerOn;
-                }
+              debug("Making status request for device %s", device.name);
+              var status = parseInt(functions.getVariable(device.id, 'status'));
+              debug("Status is ", status);
+              return status;
             },
             getRotationSpeed: function()
             {
-                speed = parseInt(VeraController.getStatus(device.id, 'level'));
+                var speed = parseInt(functions.getVariable(device.id, 'level'));
                 console.log('SPEED IS', speed);
                 return speed;
-                // return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&output_format=xml&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:Dimming1&Variable=LoadLevelStatus', resolveWithFullResponse: true}).then(function(res){
-                //     if (res.statusCode === 200)
-                //     {
-                //        data = parseInt(res.body.toString('utf8'));
-                //         this.rotationSpeed = data;
-                //
-                //         debug("Status for the fan %s is %s%", device.name, this.rotationSpeed);
-                //
-                //         return this.rotationSpeed;
-                //     }
-                //     else
-                //     {
-                //         debug("Error while getting the status for %s", device.name);
-                //         return this.rotationSpeed;
-                //     }
-                // }).catch(function (err) {
-                //     HAPnode.debug("Request error:"+err);
-                // });
+
             },
             identify: function()
             {

--- a/lib/types/fan.js
+++ b/lib/types/fan.js
@@ -10,10 +10,9 @@ module.exports = function(HAPnode, config, functions)
 
     module.newDevice = function(device)
     {
+        var VeraController = require("./../vera.js")(HAPnode, config, device);
         var Fan = {
             powerOn: (parseInt(device.status) === 1)?true:false,
-            rotationSpeed: 100,
-            onproc: false,
             changespeed: false,
 
             setPowerOn: function(on)
@@ -44,7 +43,7 @@ module.exports = function(HAPnode, config, functions)
             setRotationSpeed: function(rotationSpeed)
             {
                 // Apple sends 31.4043253660202 for Low, 66.52949452400208 for Mid, and 100 for High
-                // On Lutron RZF01 66 is the upper threshold of the Mid level, so 67 results in High speed
+                // On Leviton RZF01 66 is the upper threshold of the Mid level, so 67 results in High speed
                 // For safety we'll translate these to 25 for Low, 50 for Mid, and leave 100 for High
                 rotationSpeed = Math.floor(rotationSpeed);
                 if (rotationSpeed < 50) {
@@ -52,35 +51,27 @@ module.exports = function(HAPnode, config, functions)
                 } else if (rotationSpeed < 100){
                     rotationSpeed = 50;
                 }
-                if(this.onproc === false)
-                {
-                    this.onproc = true;
-                    this.rotationSpeed = rotationSpeed;
+                console.log('SPEED TO', rotationSpeed);
+                return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + rotationSpeed, resolveWithFullResponse: true}).then(function(res){
+                  console.log(res);
+                  if (res.statusCode === 200)
+                  {
+                      debug("The %s rotation speed has been changed to %d%", device.name, rotationSpeed);
+                  }
+                  else
+                  {
+                      debug("Error while changing %s rotation speed", device.name);
+                  }
 
-                    res = HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + this.rotationSpeed});
-                    if (res.statusCode === 200)
-                    {
-                        debug("The %s rotation speed has been changed to %d%", device.name, rotationSpeed);
-                    }
-                    else
-                    {
-                        debug("Error while changing %s rotation speed", device.name);
-                    }
+                  this.onproc = false;
 
-                    this.onproc = false;
-
-                    if(this.changespeed)
-                    {
-                        this.rotationSpeed = this.changespeed;
-                        this.changespeed = false;
-                        return this.setRotationSpeed(this.rotationSpeed);
-                    }
-                }
-                else
-                {
-                    this.changespeed = rotationSpeed;
-                    return;
-                }
+                  if(this.changespeed)
+                  {
+                      this.rotationSpeed = this.changespeed;
+                      this.changespeed = false;
+                      return this.setRotationSpeed(this.rotationSpeed);
+                  }
+                });
             },
             getStatus: function()
             {
@@ -103,24 +94,27 @@ module.exports = function(HAPnode, config, functions)
             },
             getRotationSpeed: function()
             {
-                return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&output_format=xml&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:Dimming1&Variable=LoadLevelStatus', resolveWithFullResponse: true}).then(function(res){
-                    if (res.statusCode === 200)
-                    {
-                       data = parseInt(res.body.toString('utf8'));
-                        this.rotationSpeed = data;
-
-                        debug("Status for the fan %s is %s%", device.name, this.rotationSpeed);
-
-                        return this.rotationSpeed;
-                    }
-                    else
-                    {
-                        debug("Error while getting the status for %s", device.name);
-                        return this.rotationSpeed;
-                    }
-                }).catch(function (err) { 
-                    HAPnode.debug("Request error:"+err);
-                });
+                speed = parseInt(VeraController.getStatus(device.id, 'level'));
+                console.log('SPEED IS', speed);
+                return speed;
+                // return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&output_format=xml&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:Dimming1&Variable=LoadLevelStatus', resolveWithFullResponse: true}).then(function(res){
+                //     if (res.statusCode === 200)
+                //     {
+                //        data = parseInt(res.body.toString('utf8'));
+                //         this.rotationSpeed = data;
+                //
+                //         debug("Status for the fan %s is %s%", device.name, this.rotationSpeed);
+                //
+                //         return this.rotationSpeed;
+                //     }
+                //     else
+                //     {
+                //         debug("Error while getting the status for %s", device.name);
+                //         return this.rotationSpeed;
+                //     }
+                // }).catch(function (err) {
+                //     HAPnode.debug("Request error:"+err);
+                // });
             },
             identify: function()
             {
@@ -169,14 +163,13 @@ module.exports = function(HAPnode, config, functions)
             .addCharacteristic(Characteristic.RotationSpeed)
             .on('get', function(callback) {
                 var err = null;
-                Fan.getRotationSpeed.then(function(val){
-                    callback(err, val);
-                });
-                
+                callback(err, Fan.getRotationSpeed());
+
             })
             .on('set', function(value, callback) {
-                Fan.setRotationSpeed(value);
-                callback();
+                Fan.setRotationSpeed(value).then(function(res){
+                  callback();
+                })
             });
 
         return fan;

--- a/lib/types/light.js
+++ b/lib/types/light.js
@@ -7,14 +7,14 @@ module.exports = function(HAPnode, config, functions)
     var debug           = HAPnode.debug;
 
     var module  = {};
-    
+
     module.newDevice = function(device)
     {
         var Lightbulb = {
             powerOn: (parseInt(device.status) === 1)?true:false,
-            
+
             setPower: function(on)
-            { 
+            {
                 if (on)
                 {
                     binaryState     = 1;
@@ -25,7 +25,7 @@ module.exports = function(HAPnode, config, functions)
                     binaryState     = 0;
                     Lightbulb.powerOn  = false;
                 }
-                
+
                 debug("Making request for device %s", device.name);
 
                 return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
@@ -46,30 +46,9 @@ module.exports = function(HAPnode, config, functions)
             getStatus: function()
             {
                 debug("Making request for device %s", device.name);
-                return HAPnode.request(
-                        {
-                            method: 'POST',
-                            uri: 'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status',
-                            resolveWithFullResponse: true
-                        }).then(function (res)
-                        {
-                            if (res.statusCode === 200)
-                            {
-                                data = parseInt(res.body.toString('utf8'));
-                                this.powerOn = (data === 1)?true:false;
-                                status = (this.powerOn)?'On':'Off';
-
-                                debug("Status for the light %s is %s", device.name, status);
-                                return this.powerOn;
-                            }
-                            else
-                            {
-                                debug("Error while getting the status for %s", device.name);
-                                return this.powerOn;
-                            }
-                        }.bind(this)).catch(function (err) {
-                            HAPnode.debug("Request error:"+err);
-                        });
+                status = parseInt(functions.getVariable(device.id, 'status'));
+                debug("LEVEL IS ", status)
+                return status;
             },
             identify: function()
             {
@@ -107,14 +86,12 @@ module.exports = function(HAPnode, config, functions)
             .getCharacteristic(Characteristic.On)
             .on('get', function(callback) {
                 var err = null;
-                Lightbulb.getStatus().then(function(val) {
-                                    callback(err, val);
-                            });
-                
+                callback(err, Lightbulb.getStatus());
+
             });
-          
+
         return light;
     };
-    
+
     return module;
 };

--- a/lib/types/lock.js
+++ b/lib/types/lock.js
@@ -7,15 +7,15 @@ module.exports = function(HAPnode, config, functions)
     var debug           = HAPnode.debug;
 
     var module  = {};
-    
+
     module.newDevice = function(device)
     {
         var Lock = {
             locked: (device.locked === '1')?true:false,
             lockchange: function(value)
-            { 
+            {
                 Lock.locked = true;
-                
+
                 if (value)
                 {
                     binaryState     = 1;
@@ -42,27 +42,12 @@ module.exports = function(HAPnode, config, functions)
                     HAPnode.debug("Request error:"+err);
                 });
             },
-            getLockstatus: function()
+            getLockStatus: function()
             {
                 debug("Making request on device %s",device.name);
-                return HAPnode.request({method:'GET',uri:'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:micasaverde-com:serviceId:DoorLock1&Variable=Status', resolveWithFullResponse: true}).then(function (res)
-                {
-                    if (res.statusCode === 200)
-                    {
-                        data = parseInt(res.body.toString('utf8'));
-                        this.locked = (data == 1)?true:false;
-                        status = (this.locked)?'Locked':'Unlocked';
-                        debug("Status for the lock %s is %s", device.name, status);
-                        return this.locked;
-                    }
-                    else
-                    {
-                        debug("Error while getting the status for %s", device.name);
-                        return this.locked;
-                    }
-                }).catch(function (err) {
-                    HAPnode.debug("Request error:"+err);
-                });
+                status = parseInt(functions.getVariable(device.id, 'locked'));
+                debug("Status for ", device.name, " is ", status?"locked":"unlocked");
+                return status;
             },
             identify: function()
             {
@@ -93,7 +78,7 @@ module.exports = function(HAPnode, config, functions)
             .addService(Service.LockMechanism, device.name)
             .getCharacteristic(Characteristic.LockTargetState)
             .on('set', function(value, callback) {
-                
+
                 debug('Start set process for %s with the setting %s', device.name, value);
 
                 if (value === Characteristic.LockTargetState.UNSECURED) {
@@ -120,57 +105,53 @@ module.exports = function(HAPnode, config, functions)
             .getCharacteristic(Characteristic.LockCurrentState)
             .on('get', function(callback) {
                 var err = null;
-                Lock.getLockstatus().then(function(val){
-                    if(val)
-                    {
-                        callback(err, Characteristic.LockCurrentState.SECURED);
-                    }
-                    else
-                    {
-                        callback(err, Characteristic.LockCurrentState.UNSECURED);
-                    }
-                });
+                var locked = Lock.getLockStatus();
+                if(locked)
+                {
+                    callback(err, Characteristic.LockCurrentState.SECURED);
+                }
+                else
+                {
+                    callback(err, Characteristic.LockCurrentState.UNSECURED);
+                };
             });
-            
+
         lock
             .getService(Service.LockMechanism)
             .getCharacteristic(Characteristic.LockTargetState)
             .on('get', function(callback) {
                 var err = null;
-                Lock.getLockstatus().then(function(val){
-                    if(val)
-                    {
-                        callback(err, Characteristic.LockCurrentState.SECURED);
-                    }
-                    else
-                    {
-                        callback(err, Characteristic.LockCurrentState.UNSECURED);
-                    }
-                });
-            });
-        
-        
-        setInterval(function() {
-
-            Lock.getLockstatus().then(function(val){
-                if(val)
+                var locked = Lock.getLockStatus();
+                if(locked)
                 {
-                    lock
-                    .getService(Service.LockMechanism)
-                    .setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.SECURED);
+                    callback(err, Characteristic.LockCurrentState.SECURED);
                 }
                 else
                 {
-                    lock
-                    .getService(Service.LockMechanism)
-                    .setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.UNSECURED);
-                }
+                    callback(err, Characteristic.LockCurrentState.UNSECURED);
+                };
             });
 
+
+        setInterval(function() {
+            var locked = Lock.getLockStatus();
+            if(locked)
+            {
+                lock
+                .getService(Service.LockMechanism)
+                .setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.SECURED);
+            }
+            else
+            {
+                lock
+                .getService(Service.LockMechanism)
+                .setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.UNSECURED);
+            };
+
         }, 3000);
-          
+
         return lock;
     };
-    
+
     return module;
 };

--- a/lib/types/switch.js
+++ b/lib/types/switch.js
@@ -7,14 +7,14 @@ module.exports = function(HAPnode, config, functions)
     var debug           = HAPnode.debug;
 
     var module  = {};
-    
+
     module.newDevice = function(device)
     {
         var Switch = {
             powerOn: (parseInt(device.status) === 1)?true:false,
-            
+
             setPower: function(on)
-            { 
+            {
                 if (on)
                 {
                     binaryState     = 1;
@@ -25,7 +25,7 @@ module.exports = function(HAPnode, config, functions)
                     binaryState     = 0;
                     Switch.powerOn  = false;
                 }
-                
+
                 debug("Making request for device %s", device.name);
 
                 return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
@@ -46,30 +46,33 @@ module.exports = function(HAPnode, config, functions)
             getStatus: function()
             {
                 debug("Making request for device %s", device.name);
-                return HAPnode.request(
-                        {
-                            method: 'POST',
-                            uri: 'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status',
-                            resolveWithFullResponse: true
-                        }).then(function (res)
-                        {
-                            if (res.statusCode === 200)
-                            {
-                                data = parseInt(res.body.toString('utf8'));
-                                this.powerOn = (data === 1)?true:false;
-                                status = (this.powerOn)?'On':'Off';
-
-                                debug("Status for the light %s is %s", device.name, status);
-                                return this.powerOn;
-                            }
-                            else
-                            {
-                                debug("Error while getting the status for %s", device.name);
-                                return this.powerOn;
-                            }
-                        }.bind(this)).catch(function (err) {
-                            HAPnode.debug("Request error:"+err);
-                        });
+                status = parseInt(functions.getVariable(device.id, 'status'));
+                debug("Status for ", device.name, " is ", status);
+                return status;
+                // return HAPnode.request(
+                //         {
+                //             method: 'POST',
+                //             uri: 'http://'+config.veraIP+':3480/data_request?id=variableget&DeviceNum='+device.id+'&serviceId=urn:upnp-org:serviceId:SwitchPower1&Variable=Status',
+                //             resolveWithFullResponse: true
+                //         }).then(function (res)
+                //         {
+                //             if (res.statusCode === 200)
+                //             {
+                //                 data = parseInt(res.body.toString('utf8'));
+                //                 this.powerOn = (data === 1)?true:false;
+                //                 status = (this.powerOn)?'On':'Off';
+                //
+                //                 debug("Status for the light %s is %s", device.name, status);
+                //                 return this.powerOn;
+                //             }
+                //             else
+                //             {
+                //                 debug("Error while getting the status for %s", device.name);
+                //                 return this.powerOn;
+                //             }
+                //         }.bind(this)).catch(function (err) {
+                //             HAPnode.debug("Request error:"+err);
+                //         });
             },
             identify: function()
             {
@@ -107,14 +110,12 @@ module.exports = function(HAPnode, config, functions)
             .getCharacteristic(Characteristic.On)
             .on('get', function(callback) {
                 var err = null;
-                Switch.getStatus().then(function(val) {
-                                    callback(err, val);
-                            });
-                
+                callback(err, Switch.getStatus());
+
             });
-          
+
         return switchac;
     };
-    
+
     return module;
 };

--- a/lib/vera.js
+++ b/lib/vera.js
@@ -1,12 +1,26 @@
 module.exports = function(HAPnode,config, device){
   var debug = HAPnode.debug;
   var module = {};
+  var cache;
+  function cacheStatus(){
+    HAPnode.request({
+        method:'GET',
+        uri: 'http://'+config.veraIP+':3480/data_request?id=sdata'
+    }).then(function(status){
+      cache = JSON.parse(status);
+    })
+  }
 
     module.device_url = function(request_type){
         host = 'http://'+config.veraIP+':3480/data_request'
         return host+'?id='+request_type+'&DeviceNum='+device.id
     },
-
+    module.getStatus = function(id, property){
+      device = cache.devices.find(function(device, index){
+        return device.id === id;
+      });
+      return device[property];
+    },
     module.remoteRequest = function(url, params, callback){
         debug("Requesting: %s", url);
         //HAPnode.request.debug = true
@@ -33,6 +47,12 @@ module.exports = function(HAPnode,config, device){
         var callback = function(){};
         return this.remoteRequest(url, params, callback);
     }
+
+  setInterval(function() {
+
+      cacheStatus();
+
+  }, 3000);
 
   return module;
 }

--- a/lib/vera.js
+++ b/lib/vera.js
@@ -1,25 +1,10 @@
-module.exports = function(HAPnode,config, device){
+module.exports = function(HAPnode,config,device){
   var debug = HAPnode.debug;
   var module = {};
-  var cache;
-  function cacheStatus(){
-    HAPnode.request({
-        method:'GET',
-        uri: 'http://'+config.veraIP+':3480/data_request?id=sdata'
-    }).then(function(status){
-      cache = JSON.parse(status);
-    })
-  }
 
     module.device_url = function(request_type){
         host = 'http://'+config.veraIP+':3480/data_request'
         return host+'?id='+request_type+'&DeviceNum='+device.id
-    },
-    module.getStatus = function(id, property){
-      device = cache.devices.find(function(device, index){
-        return device.id === id;
-      });
-      return device[property];
     },
     module.remoteRequest = function(url, params, callback){
         debug("Requesting: %s", url);
@@ -47,12 +32,6 @@ module.exports = function(HAPnode,config, device){
         var callback = function(){};
         return this.remoteRequest(url, params, callback);
     }
-
-  setInterval(function() {
-
-      cacheStatus();
-
-  }, 3000);
 
   return module;
 }


### PR DESCRIPTION
This commit drastically reduces the number of requests and ensures there are less "hangups" from the server.

We really don't need independent requests for each independent request from Homekit, and this can easily overwhelm the Vera.

Requests still obviously need independent requests.

- [x] Create a cacheStatus method within functions on a timer (updated every 3 seconds)
- [x] Create a getVariable method to parse that status for a device status/level/locked state
- [x] Migrate `GET` requests away from requests and instead leverage the last known status
- [x] BONUS: Fixed Fan control

I've been running this and so far so good with over 50 devices of all types.
