### PR TITLE
Stabilize dimmer/fan level set requests

### DIFF
--- a/lib/types/dimmer.js
+++ b/lib/types/dimmer.js
@@ -18,17 +18,19 @@ module.exports = function(HAPnode, config, functions)
 
             setPowerOn: function(on)
             {
+                if (on === Dimmer.powerOn)
+                   return;
+
+                Dimmer.powerOn = on;
                 if (on)
                 {
                     binaryState     = 1;
-                    Dimmer.powerOn  = true;
+                    return this.setBrightness(this.brightness);
                 }
                 else
                 {
                     binaryState     = 0;
-                    Dimmer.powerOn  = false;
                 }
-
                 return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
                 {
                     if (res.statusCode === 200)
@@ -50,6 +52,7 @@ module.exports = function(HAPnode, config, functions)
                 {
                     this.onproc = true;
                     this.brightness = brightness;
+                    var self = this;
 
                     HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + this.brightness, resolveWithFullResponse: true}).then(function (res)
                     {
@@ -61,18 +64,17 @@ module.exports = function(HAPnode, config, functions)
                         {
                             debug("Error while changing %s brightness", device.name);
                         }
+                        self.onproc = false;
+                        if(self.changebright)
+                        {
+                            self.brightness = self.changebright;
+                            self.changebright = false;
+                            return self.setBrightness(self.brightness);
+                        }
                     }).catch(function (err) {
                         HAPnode.debug("Request error:"+err);
                     });
-
-                    this.onproc = false;
-
-                    if(this.changebright)
-                    {
-                        this.brightness = this.changebright;
-                        this.changebright = false;
-                        return this.setBrightness(this.brightness);
-                    }
+                    
                 }
                 else
                 {
@@ -133,7 +135,7 @@ module.exports = function(HAPnode, config, functions)
             .on('get', function(callback) {
                 var err = null;
                 callback(err, Dimmer.getStatus());
-            });
+                });
 
         light
             .getService(Service.Lightbulb)

--- a/lib/types/fan.js
+++ b/lib/types/fan.js
@@ -13,14 +13,20 @@ module.exports = function(HAPnode, config, functions)
         var VeraController = require("./../vera.js")(HAPnode, config, device);
         var Fan = {
             powerOn: (parseInt(device.status) === 1)?true:false,
+            rotationSpeed: 100,
+            onproc: false,
             changespeed: false,
 
             setPowerOn: function(on)
             {
+                if (on === Fan.powerOn)
+                   return;
+
+                Fan.powerOn = on;
                 if (on)
                 {
                     binaryState     = 1;
-                    Fan.powerOn  = true;
+                    return this.setRotationSpeed(this.rotationSpeed);
                 }
                 else
                 {
@@ -28,17 +34,20 @@ module.exports = function(HAPnode, config, functions)
                     Fan.powerOn  = false;
                 }
 
-                res = HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState});
-
-                if (res.statusCode === 200)
+                return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
                 {
-                    status = (Fan.powerOn === 1)?'On':'Off';
-                    debug("The %s has been turned %s", device.name, status);
-                }
-                else
-                {
-                    debug("Error while turning the %s on/off %s", device.name);
-                }
+                    if (res.statusCode === 200)
+                    {
+                        status = (Fan.powerOn === 1)?'On':'Off';
+                        debug("The %s has been turned %s", device.name, status);
+                    }
+                    else
+                    {
+                        debug("Error while turning the %s on/off %s", device.name);
+                    }
+                }).catch(function (err) {
+                    HAPnode.debug("Request error:"+err);
+                });
             },
             setRotationSpeed: function(rotationSpeed)
             {
@@ -51,27 +60,39 @@ module.exports = function(HAPnode, config, functions)
                 } else if (rotationSpeed < 100){
                     rotationSpeed = 50;
                 }
-                console.log('SPEED TO', rotationSpeed);
-                return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + rotationSpeed, resolveWithFullResponse: true}).then(function(res){
-                  console.log(res);
-                  if (res.statusCode === 200)
-                  {
-                      debug("The %s rotation speed has been changed to %d%", device.name, rotationSpeed);
-                  }
-                  else
-                  {
-                      debug("Error while changing %s rotation speed", device.name);
-                  }
+                if(this.onproc === false)
+                {
+                    this.onproc = true;
+                    this.rotationSpeed = rotationSpeed;
+                    var self = this;
 
-                  this.onproc = false;
-
-                  if(this.changespeed)
-                  {
-                      this.rotationSpeed = this.changespeed;
-                      this.changespeed = false;
-                      return this.setRotationSpeed(this.rotationSpeed);
-                  }
-                });
+                    HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + this.rotationSpeed, resolveWithFullResponse: true}).then(function (res)
+                    {
+                        if (res.statusCode === 200)
+                        {
+                            debug("The %s rotation speed has been changed to %d%", device.name, rotationSpeed);
+                        }
+                        else
+                        {
+                            debug("Error while changing %s rotation speed", device.name);
+                        }
+                        self.onproc = false;
+                        if(self.changespeed)
+                        {
+                             self.rotationSpeed = self.changespeed;
+                             self.changespeed = false;
+                             return self.setRotationSpeed(self.rotationSpeed);
+                        }
+                    }).catch(function (err) {
+                        HAPnode.debug("Request error:"+err);
+                    });
+                    
+                }
+                else
+                {
+                    this.changespeed = rotationSpeed;
+                    return;
+                }
             },
             getStatus: function()
             {
@@ -127,7 +148,7 @@ module.exports = function(HAPnode, config, functions)
                 var err = null;
 
                 callback(err, Fan.getStatus());
-            });
+                });
 
         fan
             .getService(Service.Fan)
@@ -137,9 +158,8 @@ module.exports = function(HAPnode, config, functions)
                 callback(err, Fan.getRotationSpeed());
             })
             .on('set', function(value, callback) {
-                Fan.setRotationSpeed(value).then(function(res){
-                  callback();
-                })
+                Fan.setRotationSpeed(value);
+                callback();
             });
 
         return fan;


### PR DESCRIPTION
1) Just send the desired dimming level when turning "on", as Vera treats On = 100%.

2) Fix the asynchronous level set request to track the "onproc" flag properly and submit the final level set after the previous asynchronous request completes.   This was leading to the incorrect levels sometimes being set. 
 
