### PR TITLE
Fix for thermostat not adding properly

### DIFF
--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -71,7 +71,7 @@ module.exports = function (HAPnode, config, functions) {
 
             getTargetHeatingCoolingState: function(){
                 var serviceId = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1';
-                var variable = 'ModeTarget';
+                var variable = 'ModeStatus';
                 var callback = function (response){
                     if (response.statusCode === 200){
 
@@ -251,6 +251,7 @@ module.exports = function (HAPnode, config, functions) {
         var thermostatUUID = uuid.generate('device:thermostat:' + config.cardinality + ':' + device.id);
         var thermostat = new Accessory(device.name, thermostatUUID);
         thermostat.username = functions.genMac('device:' + config.cardinality + ':' + device.id);
+        thermostat.pincode = config.pincode;
         thermostat.deviceid = device.id;
 
         thermostat.on('identify', function (paired, callback) {


### PR DESCRIPTION
When trying to add my Trane thermostat, I was running into errors as seen in debug mode. These adjustments allowed me to add my thermostat to the Home iOS app.