### PR TITLE
Thermostat refactor

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -280,8 +280,9 @@ module.exports = function(HAPnode, config)
               qs: params,
               resolveWithFullResponse: true
           }).then(function(response){
-            debug('Response was: ', response);
-            callback.bind(this);
+            // debug('Response was: ', response);
+            if(callback){callback.bind(this);}
+            return response;
           }).catch(function(e){
               console.log(e);
               debug(e.error);

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -2,7 +2,6 @@ module.exports = function(HAPnode, config)
 {
     var module  = {};
     var debug = HAPnode.debug;
-
       module.cacheStatus = function(){
         debug('Caching status...');
         HAPnode.request({
@@ -11,6 +10,10 @@ module.exports = function(HAPnode, config)
         }).then(function(status){
           module.cache = JSON.parse(status);
         })
+      },
+      module.device_url = function(request_type){
+          host = 'http://'+config.veraIP+':3480/data_request'
+          return host+'?id='+request_type+'&DeviceNum='+device.id
       },
 
       module.getVariable = function(id, property){
@@ -260,7 +263,29 @@ module.exports = function(HAPnode, config)
 
           return accessories;
       },
-
+      module.remoteRequest = function(url, params, callback){
+          debug("Requesting: %s", url);
+          // HAPnode.request.debug = true
+          return HAPnode.request({
+              method:'GET',
+              uri: url,
+              qs: params,
+              resolveWithFullResponse: true
+          }).then(function(response){
+            debug('Response was: ', response);
+            callback.bind(this);
+          }).catch(function(e){
+              console.log(e);
+              debug(e.error);
+              debug(e.options);
+              debug(e.response);
+          });
+      },
+      module.executeAction = function(params){
+          var url = this.device_url('action');
+          var callback = function(){};
+          return this.remoteRequest(url, params, callback);
+      },
       module.genMac = function genMac(str)
       {
           var hash = HAPnode.hashing('md5').update(str).digest("hex").toUpperCase();

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -2,6 +2,7 @@ module.exports = function(HAPnode, config)
 {
     var module  = {};
     var debug = HAPnode.debug;
+      module.latest = function(){},
       module.cacheStatus = function(){
         debug('Caching status...');
         HAPnode.request({
@@ -11,26 +12,7 @@ module.exports = function(HAPnode, config)
           module.cache = JSON.parse(status);
         })
       },
-      module.device_url = function(request_type){
-          host = 'http://'+config.veraIP+':3480/data_request'
-          return host+'?id='+request_type+'&DeviceNum='+device.id
-      },
 
-      module.remoteRequest = function(url, params){
-          debug("Requesting: %s", url);
-          //HAPnode.request.debug = true
-          return HAPnode.request({
-              method:'GET',
-              uri: url,
-              qs: params,
-              resolveWithFullResponse: true
-          }).catch(function(e){
-              debug(e.error);
-              debug(e.options);
-              debug(e.response);
-          });
-      },
-  
       module.getVariable = function(id, property){
         // console.log('cache is', module.cache);
         if (!module.cache){
@@ -297,7 +279,7 @@ module.exports = function(HAPnode, config)
           }).then(function(response){
             // debug('Response was: ', response);
             if(callback){callback.bind(this);}
-            return response;
+            return response.body;
           }).catch(function(e){
               console.log(e);
               debug(e.error);
@@ -306,9 +288,26 @@ module.exports = function(HAPnode, config)
           });
       },
       module.executeAction = function(params){
-          var url = this.device_url('action');
+          var url = 'http://'+config.veraIP+':3480/data_request?id=lu_action&output_format=json'
           var callback = function(){};
-          return this.remoteRequest(url, params, callback);
+          var remoteRequest = this.remoteRequest;
+          // console.log('params:', params);
+          return new Promise(function(resolve, reject){
+            clearTimeout(module.latest);
+            module.latest = setTimeout(function(){
+              remoteRequest(url, params, callback)
+                .then(function(response){
+                  try{
+                    json = JSON.parse(response);
+                  }catch(e){
+                    return reject(response);
+                  }
+                  return resolve(json);
+                });
+            }, 300);
+          })
+
+          return
       },
       module.genMac = function genMac(str)
       {

--- a/lib/types/color_light.js
+++ b/lib/types/color_light.js
@@ -49,7 +49,7 @@ module.exports = function (HAPnode, config, functions) {
               // S*(R+B+G) = S*I. If we add to this (1-S)*I, where I is the total intensity,
               // the sum intensity stays constant while the ratio of colorfulness to brightness
               // goes down by S linearly relative to total Intensity, which is constant.
-                debug("Transforming: ", obj);
+                // debug("Transforming: ", obj);
                 var r, g, b, w, h = obj.h, s = obj.s / 100, v = obj.v / 100, cos_h, cos_1047_h, rgbw = Array();
                 h = h % 360; // cycle h around to 0-360 degrees
                 h = 3.14159*h/180; // Convert to radians.
@@ -158,7 +158,7 @@ module.exports = function (HAPnode, config, functions) {
                 var callback = function (response){
                     if (response.statusCode === 200){
 
-                        var vera_state = response.body;
+                        var vera_state = response;
                         if (parseInt(vera_state) > 0){
                             return true;
                         } else {
@@ -201,9 +201,9 @@ module.exports = function (HAPnode, config, functions) {
                 return functions
                     .remoteRequest(url, params)
                     .then(function (response){
-                      debug('response was ', response.body.trim());
+                      debug('response was ', response.trim());
                         var map = ['W','D','R','G','B']
-                        var body = response.body.trim();
+                        var body = response.trim();
                         color = {}
                         body.split(",").forEach(function(value){
                           channel = map[value.match(/^(\d)=/)[1]].toLowerCase()
@@ -221,10 +221,18 @@ module.exports = function (HAPnode, config, functions) {
               var serviceId = 'urn:micasaverde-com:serviceId:Color1';
               var action_name = 'SetColor';
               var action_param = 'newColorTarget';
-              var params = { action: action_name, serviceId: serviceId }
+              var params = {
+                action: action_name,
+                serviceId: serviceId,
+                DeviceNum: device.id
+              }
 
               params[action_param] = JSON.stringify(color).replace(/"|:|{|}/g,'').toUpperCase()
-              return VeraController.executeAction(params);
+              return functions
+                .executeAction(params)
+                .then(function(response){
+                  debug("Light Color set");
+                });
             },
             getBrightness: function(){
                 var that = this;
@@ -294,7 +302,7 @@ module.exports = function (HAPnode, config, functions) {
                 serviceId: 'urn:micasaverde-com:serviceId:Color1'
               })
               .then(function(response){
-                device.isRGBW = Boolean(response.body.match(/W/));
+                device.isRGBW = Boolean(response.match(/W/));
               });
         }
         var rgbLightUUID = uuid.generate('device:thermostat:' + config.cardinality + ':' + device.id);

--- a/lib/types/dimmer.js
+++ b/lib/types/dimmer.js
@@ -11,76 +11,40 @@ module.exports = function(HAPnode, config, functions)
     module.newDevice = function(device)
     {
         var Dimmer = {
-            powerOn: (parseInt(device.status) === 1)?true:false,
-            brightness: 100,
-            onproc: false,
-            changebright: false,
 
-            setPowerOn: function(on)
+            setPowerOn: function(state)
             {
-                if (on === Dimmer.powerOn)
-                   return;
+                debug("Making request for device %s", device.name);
 
-                Dimmer.powerOn = on;
-                if (on)
-                {
-                    binaryState     = 1;
-                    return this.setBrightness(this.brightness);
-                }
-                else
-                {
-                    binaryState     = 0;
-                }
-                return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
-                {
-                    if (res.statusCode === 200)
-                    {
-                        status = (Dimmer.powerOn === 1)?'On':'Off';
-                        debug("The %s has been turned %s", device.name, status);
-                    }
-                    else
-                    {
-                        debug("Error while turning the %s on/off %s", device.name);
-                    }
-                }).catch(function (err) {
-                    HAPnode.debug("Request error:"+err);
-                });
+                var service = 'urn:upnp-org:serviceId:SwitchPower1',
+                    action = 'SetTarget',
+                    value = parseInt(state);
+                functions.executeAction({
+                  action: action,
+                  serviceId: service,
+                  newTargetValue: value,
+                  DeviceNum: device.id
+                }).then(function(response){
+                  debug("Light Power set");
+                  debug(response['u:SetTargetResponse']);
+                })
             },
             setBrightness: function(brightness)
             {
-                if(this.onproc === false)
-                {
-                    this.onproc = true;
-                    this.brightness = brightness;
-                    var self = this;
+                debug("Making request for device %s", device.name);
 
-                    HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=" + this.brightness, resolveWithFullResponse: true}).then(function (res)
-                    {
-                        if (res.statusCode === 200)
-                        {
-                            debug("The %s brightness has been changed to %d%", device.name, brightness);
-                        }
-                        else
-                        {
-                            debug("Error while changing %s brightness", device.name);
-                        }
-                        self.onproc = false;
-                        if(self.changebright)
-                        {
-                            self.brightness = self.changebright;
-                            self.changebright = false;
-                            return self.setBrightness(self.brightness);
-                        }
-                    }).catch(function (err) {
-                        HAPnode.debug("Request error:"+err);
-                    });
-                    
-                }
-                else
-                {
-                    this.changebright = brightness;
-                    return;
-                }
+                var service = 'urn:upnp-org:serviceId:Dimming1',
+                    action = 'SetLoadLevelTarget',
+                    value = parseInt(brightness);
+                functions.executeAction({
+                  action: action,
+                  serviceId: service,
+                  newLoadlevelTarget: value,
+                  DeviceNum: device.id
+                }).then(function(response){
+                  debug("Light Brightness set");
+                  debug(response['u:SetTargetResponse']);
+                });
             },
             getStatus: function()
             {

--- a/lib/types/light.js
+++ b/lib/types/light.js
@@ -34,7 +34,8 @@ module.exports = function(HAPnode, config, functions)
                 functions.executeAction({
                   action: action,
                   serviceId: service,
-                  NewCurrentSetpoint: value
+                  NewCurrentSetpoint: value,
+                  DeviceNum: device.id
                 }).then(function(response){
                   debug("Light Power set");
                   debug(response);

--- a/lib/types/light.js
+++ b/lib/types/light.js
@@ -13,35 +13,47 @@ module.exports = function(HAPnode, config, functions)
         var Lightbulb = {
             powerOn: (parseInt(device.status) === 1)?true:false,
 
-            setPower: function(on)
+            setPower: function(state)
             {
-                if (on)
-                {
-                    binaryState     = 1;
-                    Lightbulb.powerOn  = true;
-                }
-                else
-                {
-                    binaryState     = 0;
-                    Lightbulb.powerOn  = false;
-                }
+                // if (on)
+                // {
+                //     binaryState     = 1;
+                //     Lightbulb.powerOn  = true;
+                // }
+                // else
+                // {
+                //     binaryState     = 0;
+                //     Lightbulb.powerOn  = false;
+                // }
 
                 debug("Making request for device %s", device.name);
 
-                return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
-                {
-                    if (res.statusCode === 200)
-                    {
-                        status = (Lightbulb.powerOn)?'On':'Off';
-                        debug("The %s has been turned %s", device.name, status);
-                    }
-                    else
-                    {
-                        debug("Error while turning the %s on/off %s", device.name);
-                    }
-                }).catch(function (err) {
-                    HAPnode.debug("Request error:"+err);
-                });
+                var service = 'urn:upnp-org:serviceId:SwitchPower1',
+                    action = 'SetTarget',
+                    value = parseInt(state);
+                functions.executeAction({
+                  action: action,
+                  serviceId: service,
+                  NewCurrentSetpoint: value
+                }).then(function(response){
+                  debug("Light Power set");
+                  debug(response);
+                })
+
+                // return HAPnode.request({method:'GET',uri:"http://"+config.veraIP+":3480/data_request?id=lu_action&output_format=xml&DeviceNum=" + device.id + "&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=" + binaryState, resolveWithFullResponse: true}).then(function (res)
+                // {
+                //     if (res.statusCode === 200)
+                //     {
+                //         status = (Lightbulb.powerOn)?'On':'Off';
+                //         debug("The %s has been turned %s", device.name, status);
+                //     }
+                //     else
+                //     {
+                //         debug("Error while turning the %s on/off %s", device.name);
+                //     }
+                // }).catch(function (err) {
+                //     HAPnode.debug("Request error:"+err);
+                // });
             },
             getStatus: function()
             {

--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -168,7 +168,6 @@ module.exports = function (HAPnode, config, functions) {
             setTargetTemperature: function(value){
                 var services, action_name, action_param, mode;
                 mode = Thermostat.getMode();
-                console.log(mode);
                 switch(mode){
                   case 1:
                     services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'];
@@ -185,12 +184,20 @@ module.exports = function (HAPnode, config, functions) {
                 };
 
                 action_name = 'SetCurrentSetpoint';
-                debug(services);
                 requests = services.map(function(service){
                   functions.executeAction({
                     action: 'SetCurrentSetpoint',
                     serviceId: service,
                     NewCurrentSetpoint: value
+                  }).then(function(response){
+                    // Dirty Hack For WWN Plugin. Uses wrong serviceId
+                    if(response.body.match(/ERROR/)){
+                      functions.executeAction({
+                        action: 'SetCurrentSetpoint',
+                        serviceId: service.match(/(^.+)_/)[1],
+                        NewCurrentSetpoint: value
+                      });
+                    }
                   })
                 });
                 debug("[After Conversion] Set Target Temperature for Thermostat #%s is %s", device.name, value);
@@ -292,7 +299,6 @@ module.exports = function (HAPnode, config, functions) {
                 debug('Setting target temp value for %s to %s', device.name, value);
                 Thermostat.setTargetTemperature(value).then(function(val){
                     // return our current value
-                    debug("Response was: ", val);
                     callback(null, val);
                 });
             });

--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -11,7 +11,6 @@ module.exports = function (HAPnode, config, functions) {
 
     module.newDevice = function (device, tempDisplayUnit) {
         var temperatureDisplayUnit = tempDisplayUnit;
-        var VeraController = require("./../vera.js")(HAPnode, config, device);
         var Thermostat = {
 
             veraIsUsingFahrenheit: function(){
@@ -26,93 +25,95 @@ module.exports = function (HAPnode, config, functions) {
                 return (temperature * 1.8) + 32;
             },
 
-            getCurrentHeatingCoolingState: function(){
-                var serviceId = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1';
-                var variable = 'ModeStatus';
-                var callback = function (response){
-                    if (response.statusCode === 200){
-                        var vera_state = response.body;
-                        var state;
-                        switch(vera_state){
-                            case "Off":
-                            case "InDeadBand":
-                                state = Characteristic.CurrentHeatingCoolingState.OFF;
-                                break;
-                            case "HeatOn":
-                            case "AuxHeatOn":
-                            case "EconomyHeatOn":
-                            case "EmergencyHeatOn":
-                            case "EnergySavingsHeating":
-                            case "BuildingProtection":
-                                state = Characteristic.CurrentHeatingCoolingState.HEAT;
-                                break;
-                            case "CoolOn":
-                            case "AuxCoolOn":
-                            case "EconomyCoolOn":
-                                state = Characteristic.CurrentHeatingCoolingState.COOL;
-                                break;
-                            default:
-                                null;
-                        }
+            getHVACState: function(){
+                var hvacstate, temperature, heat, cool;
+                debug("Making hvacstate request for device %s", device.name);
+                hvacstate = functions.getVariable(device.id, 'hvacstate');
+                temperature = parseInt(functions.getVariable(device.id, 'temperature'));
+                heat = parseInt(functions.getVariable(device.id, 'heat'));
+                cool = parseInt(functions.getVariable(device.id, 'cool'));
+                debug("HVAC State returned as: ", hvacstate);
+                if (hvacstate){
+                  switch(hvacstate){
+                      case "Idle":
+                      case "PendingHeat":
+                      case "PendingCool":
+                      case "FanOnly":
+                      case "Vent":
+                          return Characteristic.CurrentHeatingCoolingState.OFF;
+                          break;
+                      case "Heating":
+                          return Characteristic.CurrentHeatingCoolingState.HEAT;
+                          break;
+                      case "Cooling":
+                          return Characteristic.CurrentHeatingCoolingState.COOL;
+                          break;
+                      default:
+                          null;
+                  }
+                }else{
+                    mode = functions.getVariable(device.id, 'mode');
+                    switch(mode){
+                        case "Off":
+                        case "InDeadBand":
+                        case "Idle":
+                        case "eco": // Nest Plugin
 
-
-                        debug("Current Heating cooling state for Thermostat #%s is %s", device.name, state);
-                        return state;
-                    }
-                    else
-                    {
-                        debug("Error while getting the current heating cooling state for %s", device.name);
-                        return null;
-                    }
+                          return Characteristic.CurrentHeatingCoolingState.OFF;
+                          break;
+                        case "HeatOn":
+                        case "AuxHeatOn":
+                        case "EconomyHeatOn":
+                        case "EmergencyHeatOn":
+                        case "EnergySavingsHeating":
+                        case "BuildingProtection":
+                            if (heat<temperature){
+                              return Characteristic.CurrentHeatingCoolingState.OFF;
+                            }else{
+                              return Characteristic.CurrentHeatingCoolingState.HEAT;
+                            }
+                            break;
+                        case "CoolOn":
+                        case "AuxCoolOn":
+                        case "EconomyCoolOn":
+                            if (cool>temperature){
+                              return Characteristic.CurrentHeatingCoolingState.OFF;
+                            }else{
+                              return Characteristic.CurrentHeatingCoolingState.COOL;
+                            }
+                            break;
+                        default:
+                            null;
+                  }
                 }
-
-                return VeraController.getVariable(serviceId, variable, callback);
             },
 
-            getTargetHeatingCoolingState: function(){
-                var serviceId = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1';
-                var variable = 'ModeTarget';
-                var callback = function (response){
-                    if (response.statusCode === 200){
-
-                        var vera_state = response.body;
-                        var state;
-                        switch(vera_state){
-                            case "Off":
-                                state = Characteristic.TargetHeatingCoolingState.OFF;
-                                break;
-                            case "HeatOn":
-                            case "AuxHeatOn":
-                            case "EconomyHeatOn":
-                            case "EmergencyHeatOn":
-                            case "BuildingProtection":
-                                state = Characteristic.TargetHeatingCoolingState.HEAT;
-                                break;
-                            case "CoolOn":
-                            case "AuxCoolOn":
-                            case "EconomyCoolOn":
-                                state = Characteristic.TargetHeatingCoolingState.COOL;
-                                break;
-                            case "AutoChangeOver":
-                            case "EnergySavingsMode":
-                                state = Characteristic.TargetHeatingCoolingState.AUTO;
-                                break;
-                            default:
-                                null;
-                        }
-
-
-                        debug("Target Heating cooling for Thermostat #%s is %s", device.name, "0");
-                        return state;
-                    }
-                    else
-                    {
-                        debug("Error while getting the Target Heating cooling for %s", device.name);
-                        return null;
-                    }
-                }
-
-                return VeraController.getVariable(serviceId, variable, callback);
+            getMode: function(){
+                mode = functions.getVariable(device.id, 'mode');
+                switch(mode){
+                    case "Off":
+                    case "eco": // Nest Plugin
+                        return Characteristic.TargetHeatingCoolingState.OFF;
+                        break;
+                    case "HeatOn":
+                    case "AuxHeatOn":
+                    case "EconomyHeatOn":
+                    case "EmergencyHeatOn":
+                    case "BuildingProtection":
+                        return Characteristic.TargetHeatingCoolingState.HEAT;
+                        break;
+                    case "CoolOn":
+                    case "AuxCoolOn":
+                    case "EconomyCoolOn":
+                        return Characteristic.TargetHeatingCoolingState.COOL;
+                        break;
+                    case "AutoChangeOver":
+                    case "EnergySavingsMode":
+                        return Characteristic.TargetHeatingCoolingState.AUTO;
+                        break;
+                    default:
+                        null;
+              }
             },
 
             setTargetHeatingCoolingState: function(value){
@@ -137,74 +138,67 @@ module.exports = function (HAPnode, config, functions) {
                         break;
                 }
                 params[action_param] = vera_value
-                return VeraController.executeAction(params);
+                return functions.executeAction(params);
             },
 
             getCurrentTemperature: function(){
-                var serviceId = 'urn:upnp-org:serviceId:TemperatureSensor1';
-                var variable = 'CurrentTemperature';
-                var callback = function (response){
-                    if (response.statusCode === 200){
-                        data = parseFloat(response.body.toString('utf8'));
-                        debug("[Before Conversion] Current Temperature for Thermostat #%s is %s", device.name, data);
-
-                        if (this.veraIsUsingFahrenheit()){
-                            data = this.fahrenheitToCelsius(data);
-                        }
-
-                        debug("Current Temperature for Thermostat #%s is %s", device.name, data);
-                        return data;
-                    }
-                    else
-                    {
-                        debug("Error while getting the current temperature for %s", device.name);
-                        return null;
-                    }
-                }.bind(this);
-
-                return VeraController.getVariable(serviceId, variable, callback);
+                // var serviceId = 'urn:upnp-org:serviceId:TemperatureSensor1';
+                // var variable = 'CurrentTemperature';
+                debug("Making temperature request for device %s", device.name);
+                temperature = parseInt(functions.getVariable(device.id, 'temperature'));
+                debug("[Before Conversion] Current Temperature for Thermostat #%s is %s", device.name, temperature);
+                if (this.veraIsUsingFahrenheit()){
+                    temperature = this.fahrenheitToCelsius(temperature);
+                }
+                debug("Current Temperature for Thermostat #%s is %s", device.name, temperature);
+                return temperature;
             },
 
             getTargetTemperature: function(){
-                var serviceId = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat';
-                var variable = 'CurrentSetpoint';
-                var callback = function (response){
-                    if (response.statusCode === 200){
-
-                        data = parseFloat(response.body.toString('utf8'));
-                        debug("[Before Conversion] Target Temperature for Thermostat #%s is %s", device.name, data);
-
-                        if (this.veraIsUsingFahrenheit()){
-                            data = this.fahrenheitToCelsius(data);
-                        }
-
-                        debug("Target Temperature for Thermostat #%s is %s", device.name, data);
-                        return data;
-                    }
-                    else
-                    {
-                        debug("Error while getting the target temperature for %s", device.name);
-                        return null;
-                    }
-                }.bind(this);
-
-                return VeraController.getVariable(serviceId, variable, callback);
+                debug("Making setpoint request for device %s", device.name);
+                setpoint = parseInt(functions.getVariable(device.id, 'setpoint'));
+                debug("[Before Conversion] Current Temperature for Thermostat #%s is %s", device.name, setpoint);
+                if (this.veraIsUsingFahrenheit()){
+                    setpoint = this.fahrenheitToCelsius(setpoint);
+                }
+                debug("Current Temperature for Thermostat #%s is %s", device.name, setpoint);
+                return setpoint;
             },
 
             setTargetTemperature: function(value){
-                var serviceIdHeat = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat';
-                var serviceIdCool = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool';
-                var action_name = 'SetCurrentSetpoint';
-                var action_param = 'NewCurrentSetpoint';
-                var params = { action: action_name, serviceId: serviceIdHeat }
+                var services, action_name, action_param, mode;
+                mode = Thermostat.getMode();
+                console.log(mode);
+                switch(mode){
+                  case 1:
+                    services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'];
+                    break;
+                  case 2:
+                    services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'];
+                    break;
+                  case 3:
+                    services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Heat','urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'];
+                    break;
+                }
                 if (this.veraIsUsingFahrenheit()){
-                    value = this.celsiusToFahrenheit(value);
+                    value = Math.round(this.celsiusToFahrenheit(value));
                 };
-                debug("[After Conversion] SEt Target Temperature for Thermostat #%s is %s", device.name, value);
-                params[action_param] = value;
-                VeraController.executeAction(params); //Set Heat setpoint
-                params["serviceId"] = serviceIdCool;
-                return VeraController.executeAction(params); //Set Cool setpoint
+
+                action_name = 'SetCurrentSetpoint';
+                debug(services);
+                requests = services.map(function(service){
+                  functions.executeAction({
+                    action: 'SetCurrentSetpoint',
+                    serviceId: service,
+                    NewCurrentSetpoint: value
+                  })
+                });
+                debug("[After Conversion] Set Target Temperature for Thermostat #%s is %s", device.name, value);
+                //
+                return Promise.all(requests);
+                // return functions.executeAction(params); //Set Heat setpoint
+                // params["serviceId"] = serviceIdCool;
+                // return functions.executeAction(params); //Set Cool setpoint
             },
 
             getTemperatureDisplayUnits: function(){
@@ -233,7 +227,7 @@ module.exports = function (HAPnode, config, functions) {
                     }
                 };
 
-                return VeraController.getVariable(serviceId, variable, callback);
+                return functions.getVariable(serviceId, variable, callback);
             },
 
             getIsLowBattery: function (level) {
@@ -263,19 +257,13 @@ module.exports = function (HAPnode, config, functions) {
         service.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
             .on('get', function (callback) {
                 debug('Getting current heating/cooling state for %s', device.name);
-                Thermostat.getCurrentHeatingCoolingState().then(function(val){
-                    // return our current value
-                    callback(null, val);
-                });
+                callback(null, Thermostat.getHVACState());
             });
 
         service.getCharacteristic(Characteristic.TargetHeatingCoolingState)
             .on('get', function (callback) {
                 debug('Getting target heating/cooling value for %s', device.name);
-                Thermostat.getTargetHeatingCoolingState().then(function(val){
-                    // return our current value
-                    callback(null, val);
-                });
+                callback(null, Thermostat.getMode());
             });
 
         service.getCharacteristic(Characteristic.TargetHeatingCoolingState)
@@ -290,19 +278,13 @@ module.exports = function (HAPnode, config, functions) {
         service.getCharacteristic(Characteristic.CurrentTemperature)
             .on('get', function (callback) {
                 debug('Getting current temp. value for %s', device.name);
-                Thermostat.getCurrentTemperature().then(function(val){
-                    // return our current value
-                    callback(null, val);
-                });
+                callback(null, Thermostat.getCurrentTemperature());
             });
 
         service.getCharacteristic(Characteristic.TargetTemperature)
             .on('get', function (callback) {
                 debug('Getting target temp value for %s', device.name);
-                Thermostat.getTargetTemperature().then(function(val){
-                    // return our current value
-                    callback(null, val);
-                });
+                callback(null, Thermostat.getTargetTemperature());
             });
 
         service.getCharacteristic(Characteristic.TargetTemperature)
@@ -310,6 +292,7 @@ module.exports = function (HAPnode, config, functions) {
                 debug('Setting target temp value for %s to %s', device.name, value);
                 Thermostat.setTargetTemperature(value).then(function(val){
                     // return our current value
+                    debug("Response was: ", val);
                     callback(null, val);
                 });
             });

--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -146,8 +146,6 @@ module.exports = function (HAPnode, config, functions) {
             },
 
             getCurrentTemperature: function(){
-                // var serviceId = 'urn:upnp-org:serviceId:TemperatureSensor1';
-                // var variable = 'CurrentTemperature';
                 debug("Making temperature request for device %s", device.name);
                 temperature = parseInt(functions.getVariable(device.id, 'temperature'));
                 debug("[Before Conversion] Current Temperature for Thermostat #%s is %s", device.name, temperature);
@@ -212,9 +210,6 @@ module.exports = function (HAPnode, config, functions) {
                 debug("[After Conversion] Set Target Temperature for Thermostat #%s is %s", device.name, value);
                 //
                 return Promise.all(requests);
-                // return functions.executeAction(params); //Set Heat setpoint
-                // params["serviceId"] = serviceIdCool;
-                // return functions.executeAction(params); //Set Cool setpoint
             },
 
             getTemperatureDisplayUnits: function(){

--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -116,11 +116,15 @@ module.exports = function (HAPnode, config, functions) {
               }
             },
 
-            setTargetHeatingCoolingState: function(value){
+            setMode: function(value){
                 var serviceId = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1';
                 var action_name = 'SetModeTarget';
                 var action_param = 'NewModeTarget';
-                var params = { action: action_name, serviceId: serviceId }
+                var params = {
+                  action: action_name,
+                  serviceId: serviceId,
+                  DeviceNum: device.id
+                }
                 var vera_value;
 
                 switch(value){
@@ -188,13 +192,18 @@ module.exports = function (HAPnode, config, functions) {
                   functions.executeAction({
                     action: 'SetCurrentSetpoint',
                     serviceId: service,
+                    DeviceNum: device.id,
                     NewCurrentSetpoint: value
                   }).then(function(response){
+
+                  }).catch(function(response){
+                    console.log("response was:", typeof(response));
                     // Dirty Hack For WWN Plugin. Uses wrong serviceId
-                    if(response.body.match(/ERROR/)){
+                    if(typeof(response) === 'string' && response.match(/ERROR/)){
                       functions.executeAction({
                         action: 'SetCurrentSetpoint',
                         serviceId: service.match(/(^.+)_/)[1],
+                        DeviceNum: device.id,
                         NewCurrentSetpoint: value
                       });
                     }
@@ -277,7 +286,7 @@ module.exports = function (HAPnode, config, functions) {
         service.getCharacteristic(Characteristic.TargetHeatingCoolingState)
             .on('set', function (value, callback) {
                 debug('Setting target heating/cooling value for %s', device.name);
-                Thermostat.setTargetHeatingCoolingState(value).then(function(val){
+                Thermostat.setMode(value).then(function(val){
                     // return our current value
                     callback(null, val);
                 });


### PR DESCRIPTION
Resolving multiple items here:

- [x] Leveraging hvacstate for current status.  this allows logical separation between mode and current activity
- [x] Provides fallback for systems that do not have hvacstate.  As far as I can tell, this is only currently for the Nest (WWN) plugin.  Any compliant Z-Wave thermostat *should* have hvacstate
- [x] Provides hack for Nest as current vera plugin uses incorrect service address.
- [x] Migration of executeAction to functions instead of `vera.js` this is probably a better place for global methods.