### PR TITLE
set contact sensor values as numbers, but keep 0 or 1

### DIFF
--- a/lib/types/sensor.js
+++ b/lib/types/sensor.js
@@ -167,6 +167,7 @@ module.exports = function (HAPnode, config, functions) {
               var value = parseInt(functions.getVariable(device.id, map.getVariable));
               if(map.type == 'boolean'){
                 value = Boolean(value);
+                value = Number(value);
               }
               callback(null, value);
             });
@@ -176,6 +177,7 @@ module.exports = function (HAPnode, config, functions) {
             var value = parseInt(functions.getVariable(device.id, map.getVariable));
             if(map.type == 'boolean'){
               value = Boolean(value);
+              value = Number(value);
             }
             if (value !== service.getCharacteristic(characteristic).value){
               service.setCharacteristic(characteristic,value);


### PR DESCRIPTION
Just picked up a few Door/Window sensors, but they weren't reporting the correct status in homebridge. After some browsing, I came across [this comment](https://github.com/damianxd/homebridge-vera/issues/119#issuecomment-324908487). Decided to give the idea a go and it worked like a charm so here's the fix.