### PR TITLE
ignore all scenes via config

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -103,7 +103,7 @@ module.exports = function(HAPnode, config)
 
       module.getEnabledScenes = function (verainfo) {
         return verainfo.scenes.filter( (scene) => {
-          const found = (!config.ignorescenes || (config.ignorescenes && config.ignorescenes.indexOf(scene.id) < 0));
+          const found = (!config.ignorescenes || ((config.ignorescenes instanceof Array && config.ignorescenes.indexOf(scene.id) < 0) && config.ignorescenes !== true));
           if (!found) {
             HAPnode.debug('Ignore Scene: ', scene.id, '-', scene.name);
           }


### PR DESCRIPTION
I wanted the ability to ignore all my Vera scenes without having to lookup the device/scene numbers. Config examples below:

--- 

Ignores all scenes
```
"ignorescenes": true,
```

--- 

Ignores no scenes
```
"ignorescenes": false,
```

--- 

Ignores no scenes
```
"ignorescenes": [],
```

--- 

Ignores 1 scene
```
"ignorescenes": [26],
```