### PR TITLE
Fix map error for "off" thermostat mode

### DIFF
--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -180,7 +180,7 @@ module.exports = function (HAPnode, config, functions) {
                   case 2:
                     services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'];
                     break;
-                  case 3:
+                  default:
                     services = ['urn:upnp-org:serviceId:TemperatureSetpoint1_Heat','urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'];
                     break;
                 }


### PR DESCRIPTION
This should fix #125 and #129. I tested this with a CT100 and it sets the setpoint as expected.
  