### PR TITLE
ignore device via plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Edit your homebridge config.json file located on **~/.homebridge/config.json** a
             "garageLocks": [23],
             "ignoredevices":[24,25],
             "ignorescenes":[26,27],
+            "ignoreplugins": ["Nest","PhilipsHue","Wemo"],
             "houseModes": false
         }
     ]

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -117,6 +117,20 @@ module.exports = function(HAPnode, config)
       {
           var devices = verainfo.devices_full_list.filter(function(device){
                   var found = (!config.ignoredevices || (config.ignoredevices && config.ignoredevices.indexOf(device.id)<0));
+
+                  // Check to see if we need to ignore plugins
+                  if (found && Array.isArray(config.ignoreplugins)) {
+                    var shouldIgnore = config.ignoreplugins.filter(function(plugin){
+                      var deviceTypeMatch = device.device_type.toLowerCase().indexOf(plugin.toLowerCase()) > -1;
+                      var altIdMatch = device.altid && device.altid.toLowerCase().indexOf(plugin.toLowerCase()) > -1;
+                      return deviceTypeMatch || altIdMatch;
+                    })
+                    if (shouldIgnore.length) {
+                      HAPnode.debug("Ignore Device (via Plugin:",shouldIgnore.join(', ')+"): ", device.id, "-", device.name);
+                      return false;
+                    }
+                  }
+
                   if (!found){
                     HAPnode.debug("Ignore Device: ", device.id, "-", device.name);
                   }


### PR DESCRIPTION
I thought it would be nice to be able to ignore certain Vera plugins via name. The three plugins in the modified README have been tested, and are HomeKit compatible via a manufacturer's bridge or through other Homebridge plugins.