### PR TITLE
Support Garage Door Opener

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -331,6 +331,12 @@ module.exports = function(HAPnode, config)
                           accessories.push(Lock.newDevice(device));
                       break;
 
+                  case 32: // Garage Door
+                          var GarageDoor            = require("./types/garage_door.js")(HAPnode,config,module);
+                          HAPnode.debug('------ Garage Door Added: %s', device.name + ' ID:' +device.id);
+                          accessories.push(GarageDoor.newDevice(device));
+                      break;
+
                   case 8: // Window covering
                           HAPnode.debug('------ Window covering found: %s', device.name + ' ID:' +device.id);
                           var wc = require("./types/windowcovering.js")(HAPnode,config,module);

--- a/lib/types/garage_door.js
+++ b/lib/types/garage_door.js
@@ -1,0 +1,133 @@
+module.exports = function(HAPnode, config, functions)
+{
+    var Accessory       = HAPnode.Accessory;
+    var Service         = HAPnode.Service;
+    var Characteristic  = HAPnode.Characteristic;
+    var uuid            = HAPnode.uuid;
+    var debug           = HAPnode.debug;
+
+    var module  = {};
+
+    module.newDevice = function(device)
+    {
+        var GarageDoor = {
+            opened: (parseInt(device.status) === 1) ? true : false,
+            setTarget: function(opened)
+            {
+              var value = opened ? 1 : 0;
+
+              return functions.executeAction({
+                action: 'SetTarget',
+                serviceId: 'urn:upnp-org:serviceId:SwitchPower1',
+                newTargetValue: value,
+                DeviceNum: device.id
+              }).then(function(response){
+                GarageDoor.opened = !!opened;
+                return opened;
+              })
+            },
+            getGarageDoorStatus: function()
+            {
+                // debug("Making request on device %s",device.name);
+                status = parseInt(functions.getVariable(device.id, 'status'));
+                // debug("Status for ", device.name, " is ", status?"openned":"closed");
+                return status;
+            },
+            identify: function()
+            {
+                debug("Identify the accessory!");
+            }
+        };
+
+        var hapuuid = uuid.generate('device:garage:'+config.cardinality+':'+device.id);
+        var service = Service.GarageDoorOpener;
+
+        var accessory = new Accessory(device.name, hapuuid);
+
+        accessory.username   = functions.genMac('device:'+config.cardinality+':'+device.id);
+        accessory.pincode    = config.pincode;
+        accessory.deviceid   = device.id;
+
+        accessory
+            .getService(Service.AccessoryInformation)
+            .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
+            .setCharacteristic(Characteristic.Model, device.model)
+            .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        accessory.on('identify', function(paired, callback) {
+            GarageDoor.identify();
+            callback(); // success
+        });
+
+        accessory
+            .addService(service, device.name)
+            .getCharacteristic(Characteristic.TargetDoorState)
+            .on('set', function(value, callback) {
+                debug('Start set process for %s with the setting %s', device.name, value);
+                var opened = value === Characteristic.TargetDoorState.OPEN;
+                GarageDoor.setTarget(opened).then(function(opened){
+                  debug('GarageDoor.setTarget complete:', opened);
+                  var state = opened ? Characteristic.CurrentDoorState.OPEN : Characteristic.CurrentDoorState.CLOSED;
+                  callback();
+                  accessory
+                    .getService(service)
+                    .setCharacteristic(Characteristic.CurrentDoorState, state);
+
+                })
+            });
+
+        accessory
+            .getService(service)
+            .getCharacteristic(Characteristic.CurrentDoorState)
+            .on('get', function(callback) {
+                var err = null;
+                var opened = GarageDoor.getGarageDoorStatus();
+                if(opened)
+                {
+                    callback(err, Characteristic.CurrentDoorState.OPEN);
+                }
+                else
+                {
+                    callback(err, Characteristic.CurrentDoorState.CLOSED);
+                };
+            });
+
+        accessory
+            .getService(service)
+            .getCharacteristic(Characteristic.TargetDoorState)
+            .on('get', function(callback) {
+                var err = null;
+                var opened = GarageDoor.getGarageDoorStatus();
+                if(opened)
+                {
+                    callback(err, Characteristic.CurrentDoorState.OPEN);
+                }
+                else
+                {
+                    callback(err, Characteristic.CurrentDoorState.CLOSED);
+                };
+            });
+
+
+        setInterval(function() {
+            var opened = GarageDoor.getGarageDoorStatus();
+            if(opened)
+            {
+                accessory
+                .getService(service)
+                .setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPEN);
+            }
+            else
+            {
+                accessory
+                .getService(service)
+                .setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
+            };
+
+        }, 3000);
+
+        return accessory;
+    };
+
+    return module;
+};


### PR DESCRIPTION
Add support for Z-wave Garage Door Opener in Vera (category #32). This implementation is tested on Vera Plus + Linear GD00Z-4.

Note: 
* This is not for the Garage Door Opener simulator in Vera, but for actual z-wave opener.
* Most of code is based on `lock.js`