### PR TITLE
Windowcovering accessory: several fixes

### DIFF
--- a/lib/types/windowcovering.js
+++ b/lib/types/windowcovering.js
@@ -11,7 +11,6 @@ module.exports = function(HAPnode, config, functions)
     module.newDevice = function(device)
     {
         var self = this;
-        const VERA_REF = "urn:upnp-org:serviceId:WindowCovering1";
         const VERA_ACTION =
         {
             DOWN : { ref: "Down", state : 0},
@@ -27,30 +26,74 @@ module.exports = function(HAPnode, config, functions)
 
         //// Runtime states
         self.lastPosition = 0; //// Closed by default
+        self.currentTargetPosition = undefined;
         self.currentPositionState = VERA_ACTION.STOP.state; //// STOP by default
-        self.currentTargetPosition = VERA_ACTION.DOWN.state; //// DOWN by default
 
-        self.formatUrl = (action) =>  { return `http://${config.veraIP}:3480/data_request?id=lu_action&output_format=xml&DeviceNum=${device.id}&serviceId=${VERA_REF}&action=${action}` };
+        self.formatUrl = (targetPosition, action) =>  {
+            const base = `http://${config.veraIP}:3480/data_request?id=lu_action&output_format=xml&DeviceNum=${device.id}`;
+            // If an absolute position is provided, always send that to vera and let it decide what to do.
+            if (typeof targetPosition === 'number' && targetPosition >= 0) {
+                return `${base}&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=${targetPosition}`;
+            } else if (action === VERA_ACTION.STOP) {
+                return `${base}&serviceId=urn:upnp-org:serviceId:WindowCovering1&action=${action.ref}`;
+            } else {
+                throw new Error(`Invalid input targetPosition=${targetPosition}, action=${action}`);
+            }
+        };
+
+        self.getLastPosition = () => {
+            // Prefer the latest cached value (we poll Vera every ~1s). Fall back to our last-set value.
+            const level = functions.getVariable(device.id, 'level', 'number');
+            if (typeof level === 'number') {
+                return level;
+            } else {
+                return self.lastPosition;
+            }
+        };
+
+        self.getTargetPosition = () => {
+            if (typeof self.currentTargetPosition === 'number') {
+                return self.currentTargetPosition;
+            } else {
+                return self.getLastPosition();
+            }
+        };
 
         self.setAction = (pos, callback) =>
         {
+            const lastPosition = self.getLastPosition();
             self.currentTargetPosition = pos;
-            const action = (pos === -1 ? VERA_ACTION.STOP : (pos >= self.lastPosition ? VERA_ACTION.UP : VERA_ACTION.DOWN)).ref;
+            let action;
+            if (pos === -1 || pos === lastPosition) {
+                action = VERA_ACTION.STOP;
+            } else if (pos < lastPosition) {
+                action = VERA_ACTION.DOWN;
+            } else if (pos > lastPosition) {
+                action = VERA_ACTION.UP;
+            } else {
+                throw new Error(`Comparison logic error.`);
+            }
+
             self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, action.state);
+            debug("Setting position for %s: %s (%s)", device.name, pos, action);
 
             return HAPnode.request(
                 {
                     method:'GET',
-                    uri : self.formatUrl(action),
+                    uri : self.formatUrl(pos, action),
                     resolveWithFullResponse: true}
                 )
                 .then(function (res)
                 {
-                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.CurrentPosition, (action === VERA_ACTION.UP.ref ? 100 : 0));
-                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, 2); //// Stop state
-                    self.lastPosition = (action == VERA_ACTION.UP.ref ? 100 : 0);
+                    self.currentPositionState = VERA_ACTION.STOP.state
+                    self.currentTargetPosition = undefined;
+                    self.lastPosition = pos;
+                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.CurrentPosition, pos);
+                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, self.currentPositionState);
                     callback(false);
                 }).catch(function (err) {
+                    self.currentPositionState = VERA_ACTION.STOP.state
+                    self.currentTargetPosition = undefined;
                     HAPnode.debug("Request error:"+err);
                     callback(false);
                 });
@@ -92,7 +135,7 @@ module.exports = function(HAPnode, config, functions)
         self.component
             .addService(Service.WindowCovering, device.name)
             .getCharacteristic(Characteristic.CurrentPosition)
-            .on('get', (callback) => { debug(`Position State ${self.lastPosition}`); callback(null, self.lastPosition); });
+            .on('get', (callback) => { debug(`${device.name} Position ${self.getLastPosition()}`); callback(null, self.getLastPosition()); });
 
         // the position state
         // 0 = DECREASING; 1 = INCREASING; 2 = STOPPED;
@@ -100,14 +143,14 @@ module.exports = function(HAPnode, config, functions)
         self.component
             .getService(Service.WindowCovering)
             .getCharacteristic(Characteristic.PositionState)
-            .on('get', (callback) => { debug(`Position State ${self.currentPositionState}`); callback(null, self.currentPositionState); });
+            .on('get', (callback) => { debug(`${device.name} Position State ${self.currentPositionState}`); callback(null, self.currentPositionState); });
 
         // the target position (0-100%)
         // https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L1564
         self.component
             .getService(Service.WindowCovering)
             .getCharacteristic(Characteristic.TargetPosition)
-            .on('get', (callback) => { callback(null, self.currentTargetPosition); })
+            .on('get', (callback) => { debug(`${device.name} Target Position ${self.getTargetPosition()}`);callback(null, self.getTargetPosition()); })
             .on('set', self.setAction.bind(this));
 
         self.component


### PR DESCRIPTION
This fixes/improves a few things about the windowcovering accessory.

- We no longer strictly assume the accessory is 0% (closed) at service start. This fixes the bug where, if your blind *wasn't* closed, asking siri to open it would actually result in the the blind closing — the opposite of what you wanted.
- We no longer rely on remembering `lastPosition`, and instead use the cached value available via `functions.getVariable`. This fixes the bug where, if you change your blinds through another kind of control (using Vera UI directly), asking siri to open/close could result in the opposite thing happening.
- We're now able to set your accessory to a specific position %. This fixes the bug where, if a user of the Home app clicks on a partially open setting, the blind would move in that direction but go all the way to 0% or 100% (depending).

To test/use this yourself, within your homebridge installation:
```
$ npm install --save igrayson/homebridge-vera#igrayson/windowcovering-refac
```