### PR TITLE
Change windowcovering.js to read/write load levels

### DIFF
--- a/lib/types/windowcovering.js
+++ b/lib/types/windowcovering.js
@@ -11,12 +11,18 @@ module.exports = function(HAPnode, config, functions)
     module.newDevice = function(device)
     {
         var self = this;
-        const VERA_ACTION =
-        {
-            DOWN : { ref: "Down", state : 0},
-            UP : { ref: "Up", state : 1},
-            STOP : { ref: "Stop", state : 2},
-        };
+        
+        // The former version of this acted like a toggle and "blindly" sent WindowCovering1 commands to raise or lower,
+        // but Vera will present a dimmer in addition to the WindowCovering1 that can read position and move blinds more closely
+        // to what HomeKit expects.  
+
+        // const VERA_REF = "urn:upnp-org:serviceId:WindowCovering1";
+        // const VERA_ACTION =
+        // {
+        //    DOWN : { ref: "Down", state : Characteristic.PositionState.DECREASING},
+        //    UP : { ref: "Up", state : Characteristic.PositionState.INCREASING},
+        //    STOP : { ref: "Stop", state : Characteristic.PositionState.STOPPED},
+        //};
 
         //// Initializing accessory
         self.component = new Accessory(device.name, uuid.generate(`device:windowcovering:${config.cardinality}:${device.id}`));
@@ -25,75 +31,33 @@ module.exports = function(HAPnode, config, functions)
         self.component.deviceid  = device.id;
 
         //// Runtime states
-        self.lastPosition = 0; //// Closed by default
-        self.currentTargetPosition = undefined;
-        self.currentPositionState = VERA_ACTION.STOP.state; //// STOP by default
-
-        self.formatUrl = (targetPosition, action) =>  {
-            const base = `http://${config.veraIP}:3480/data_request?id=lu_action&output_format=xml&DeviceNum=${device.id}`;
-            // If an absolute position is provided, always send that to vera and let it decide what to do.
-            if (typeof targetPosition === 'number' && targetPosition >= 0) {
-                return `${base}&serviceId=urn:upnp-org:serviceId:Dimming1&action=SetLoadLevelTarget&newLoadlevelTarget=${targetPosition}`;
-            } else if (action === VERA_ACTION.STOP) {
-                return `${base}&serviceId=urn:upnp-org:serviceId:WindowCovering1&action=${action.ref}`;
-            } else {
-                throw new Error(`Invalid input targetPosition=${targetPosition}, action=${action}`);
-            }
-        };
-
-        self.getLastPosition = () => {
-            // Prefer the latest cached value (we poll Vera every ~1s). Fall back to our last-set value.
-            const level = functions.getVariable(device.id, 'level', 'number');
-            if (typeof level === 'number') {
-                return level;
-            } else {
-                return self.lastPosition;
-            }
-        };
-
-        self.getTargetPosition = () => {
-            if (typeof self.currentTargetPosition === 'number') {
-                return self.currentTargetPosition;
-            } else {
-                return self.getLastPosition();
-            }
-        };
+        self.currentPositionState = Characteristic.PositionState.STOPPED;
+        self.currentTargetPosition = 100;
 
         self.setAction = (pos, callback) =>
         {
-            const lastPosition = self.getLastPosition();
-            self.currentTargetPosition = pos;
-            let action;
-            if (pos === -1 || pos === lastPosition) {
-                action = VERA_ACTION.STOP;
-            } else if (pos < lastPosition) {
-                action = VERA_ACTION.DOWN;
-            } else if (pos > lastPosition) {
-                action = VERA_ACTION.UP;
-            } else {
-                throw new Error(`Comparison logic error.`);
-            }
+            debug(`Set window covering ${device.id} Current Position is ${pos}`);
+            self.currentPositionState = (pos > parseInt(functions.getVariable(device.id, 'level')) ? Characteristic.PositionState.INCREASING : Characteristic.PositionState.DECREASING);
+            self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, self.currentPositionState);
 
-            self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, action.state);
-            debug("Setting position for %s: %s (%s)", device.name, pos, action);
-
-            return HAPnode.request(
+            return functions.executeAction({
+                action: 'SetLoadLevelTarget',
+                serviceId: 'urn:upnp-org:serviceId:Dimming1',
+                newLoadlevelTarget: pos,
+                DeviceNum: device.id
+            }).then(function (res)
                 {
-                    method:'GET',
-                    uri : self.formatUrl(pos, action),
-                    resolveWithFullResponse: true}
-                )
-                .then(function (res)
-                {
-                    self.currentPositionState = VERA_ACTION.STOP.state
-                    self.currentTargetPosition = undefined;
-                    self.lastPosition = pos;
-                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.CurrentPosition, pos);
-                    self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, self.currentPositionState);
+                    // In my testing homekit needs a delay otherwise it will show "opening..." or "closing..." indefinitely
+                    // TODO: Might be possible to ask Vera for the actual motor status as it is shown in UI?
+                    // but this seems good enough for now.
+                    setTimeout(function(){
+                        debug("Setting stop state")
+                        self.currentPositionState =  Characteristic.PositionState.STOPPED;
+                        self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.PositionState, self.currentPositionState);
+                        self.component.getService(Service.WindowCovering).setCharacteristic(Characteristic.CurrentPosition, pos);                
+                      }, 5000);
                     callback(false);
                 }).catch(function (err) {
-                    self.currentPositionState = VERA_ACTION.STOP.state
-                    self.currentTargetPosition = undefined;
                     HAPnode.debug("Request error:"+err);
                     callback(false);
                 });
@@ -106,16 +70,15 @@ module.exports = function(HAPnode, config, functions)
         self.getStatus = () =>
         {
             debug("Making request for device %s", device.name);
-            status = functions.getVariable(device.id, 'status','number');
+            status = parseInt(functions.getVariable(device.id, 'status'));
             debug("Status for ", device.name, " is ", status);
             return status;
         };
 
         self.identify = () =>
         {
-            debug("I'm the fucking window covering.");
+            debug("Window covering.");
         };
-
 
         //// Starting initilization
         self.component
@@ -135,7 +98,11 @@ module.exports = function(HAPnode, config, functions)
         self.component
             .addService(Service.WindowCovering, device.name)
             .getCharacteristic(Characteristic.CurrentPosition)
-            .on('get', (callback) => { debug(`${device.name} Position ${self.getLastPosition()}`); callback(null, self.getLastPosition()); });
+            .on('get', (callback) => { 
+                var pos = parseInt(functions.getVariable(device.id, 'level'));
+                debug(`Window covering ${device.id} Current Position is ${pos}`);
+                callback(null, pos);
+             });
 
         // the position state
         // 0 = DECREASING; 1 = INCREASING; 2 = STOPPED;
@@ -143,14 +110,17 @@ module.exports = function(HAPnode, config, functions)
         self.component
             .getService(Service.WindowCovering)
             .getCharacteristic(Characteristic.PositionState)
-            .on('get', (callback) => { debug(`${device.name} Position State ${self.currentPositionState}`); callback(null, self.currentPositionState); });
+            .on('get', (callback) => { 
+                debug(`Window Covering ${device.id} Position State`); 
+                callback(null, self.currentPositionState); 
+            });
 
         // the target position (0-100%)
         // https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L1564
         self.component
             .getService(Service.WindowCovering)
             .getCharacteristic(Characteristic.TargetPosition)
-            .on('get', (callback) => { debug(`${device.name} Target Position ${self.getTargetPosition()}`);callback(null, self.getTargetPosition()); })
+            .on('get', (callback) => { callback(null,  parseInt(functions.getVariable(device.id, 'level'))); })
             .on('set', self.setAction.bind(this));
 
         self.component


### PR DESCRIPTION
Fixes #159 

I got some nice new Bali / Somfy Z-wave shades, that are perfectly supported by Vera.   But I found the homekit integration was severely lacking.    It was not reading the current state so they always showed default of closed, and only sending up/down commands.   It also had a bug that was sending an incorrect state type back to Homebridge.   

This of course could break simpler window covering implementations that do not support positional tracking, but I think this ought to be the default since it's much closer to what Homekit expects.   And per above issue 159, it's not just Bali/Somfy that works this way.     Not sure what the best way to go about support both would be.   Not sure if we have the ability to see what command sets a target device supports? 

Feel free to take this PR and change it / improve however you see fit.  It works well for my needs. 