### PR TITLE
Eliminate startup warnings for model characteristic

### DIFF
--- a/lib/types/color_light.js
+++ b/lib/types/color_light.js
@@ -311,9 +311,13 @@ module.exports = function (HAPnode, config, functions) {
         rgbLight
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
 
+        if (device.model) {
+            rgbLight
+              .getService(Service.AccessoryInformation)
+              .setCharacteristic(Characteristic.Model, device.model);
+        }
         var service = new Service.Lightbulb(device.name);
 
         service

--- a/lib/types/dimmer.js
+++ b/lib/types/dimmer.js
@@ -74,8 +74,13 @@ module.exports = function(HAPnode, config, functions)
         light
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+            light
+              .getService(Service.AccessoryInformation)
+              .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         light.on('identify', function(paired, callback) {
             Dimmer.identify();

--- a/lib/types/fan.js
+++ b/lib/types/fan.js
@@ -128,8 +128,13 @@ module.exports = function(HAPnode, config, functions)
         fan
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+            fan
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }        
 
         fan.on('identify', function(paired, callback) {
             Fan.identify();

--- a/lib/types/garage_door.js
+++ b/lib/types/garage_door.js
@@ -51,9 +51,13 @@ module.exports = function(HAPnode, config, functions)
         accessory
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
 
+        if (device.model) {
+            accessory
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
         accessory.on('identify', function(paired, callback) {
             GarageDoor.identify();
             callback(); // success

--- a/lib/types/lock.js
+++ b/lib/types/lock.js
@@ -63,8 +63,13 @@ module.exports = function(HAPnode, config, functions)
         accessory
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+            accessory
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         accessory
           .on('identify', function(paired, callback) {

--- a/lib/types/sensor.js
+++ b/lib/types/sensor.js
@@ -141,8 +141,13 @@ module.exports = function (HAPnode, config, functions) {
         accessory
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+          accessory
+            .getService(Service.AccessoryInformation)
+            .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         Object.keys(serviceMap.characteristics).forEach(function(key){
 

--- a/lib/types/switch.js
+++ b/lib/types/switch.js
@@ -65,8 +65,13 @@ module.exports = function(HAPnode, config, functions)
         switchac
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+            switchac
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         switchac.on('identify', function(paired, callback) {
             Switch.identify();

--- a/lib/types/tempsense.js
+++ b/lib/types/tempsense.js
@@ -50,8 +50,13 @@ module.exports = function(HAPnode, config, functions)
         sensor
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+        
+        if (device.model) {
+            sensor
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         sensor
             .addService(Service.TemperatureSensor)

--- a/lib/types/thermostat.js
+++ b/lib/types/thermostat.js
@@ -245,8 +245,13 @@ module.exports = function (HAPnode, config, functions) {
         thermostat
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+
+        if (device.model) {
+            thermostat
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         thermostat.on('identify', function (paired, callback) {
             Thermostat.identify();

--- a/lib/types/windowcovering.js
+++ b/lib/types/windowcovering.js
@@ -84,8 +84,13 @@ module.exports = function(HAPnode, config, functions)
         self.component
             .getService(Service.AccessoryInformation)
             .setCharacteristic(Characteristic.Manufacturer, device.manufacturer)
-            .setCharacteristic(Characteristic.Model, device.model)
             .setCharacteristic(Characteristic.SerialNumber, "Vera ID: "+device.id);
+        
+        if (device.model) {
+            self.component
+                .getService(Service.AccessoryInformation)
+                .setCharacteristic(Characteristic.Model, device.model);
+        }
 
         //// Runtime Events
         self.component.on('identify', function(paired, callback) {


### PR DESCRIPTION
Fixes warnings caused by setting a blank model to an accessory. Mentioned in PR#187(merged)  but wasn't fixed there.